### PR TITLE
version 0.9.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 #### 1.N.N - YYYY-MM-DD
 
 
+#### 0.9.7 - 2022-03-NN
+
+- index: previousName -> previousOwner
+-
+
+
 #### 0.9.6 - 2022-03-27
 
 - rr*: rename name -> owner (not overloaded)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,15 @@
 #### 1.N.N - YYYY-MM-DD
 
 
-#### 0.9.7 - 2022-03-27
+#### 0.9.7 - 2022-03-29
 
-- index: previousName -> previousOwner
+- index
+    - previousName -> previousOwner
+    - export a TYPE_MAP (id => name)
 - isValidHostname: allow \ char
-
+- add the word 'RFC' in error messages citing RFCs
+- when rejecting hostname, show the rejected character
+- maradns: add export support
 
 
 #### 0.9.6 - 2022-03-27

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,15 +2,16 @@
 #### 1.N.N - YYYY-MM-DD
 
 
-#### 0.9.7 - 2022-03-NN
+#### 0.9.7 - 2022-03-27
 
 - index: previousName -> previousOwner
--
+- isValidHostname: allow \ char
+
 
 
 #### 0.9.6 - 2022-03-27
 
-- rr*: rename name -> owner (not overloaded)
+- rr\*: rename name -> owner (not overloaded)
 - RFC 4034: letters in DNS names are lower cased
 - README: added definitions
 - repo: move from msimerson -> nictool org

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ This module is used to:
     - [BIND](https://www.isc.org/bind/) zone [file format](https://bind9.readthedocs.io/en/latest/reference.html#zone-file)
     - tinydns [data format](https://cr.yp.to/djbdns/tinydns-data.html)
 - export RRs to:
-    - BIND zone file format
-    - tinydns data format
+    - BIND zone files
+    - tinydns data
+    - maradns
     - JS object
     - JSON
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dns-resource-record",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "DNS Resource Records",
   "main": "rr/index.js",
   "scripts": {

--- a/rr/caa.js
+++ b/rr/caa.js
@@ -12,7 +12,7 @@ class CAA extends RR {
     this.is8bitInt('CAA', 'flags', val)
 
     if (![ 0, 128 ].includes(val)) {
-      throw new Error(`CAA flags ${val} not recognized, RFC ${this.getRFCs()}`)
+      throw new Error(`CAA flags ${val} not recognized, ${this.citeRFC()}`)
     }
 
     this.set('flags', val)
@@ -22,10 +22,10 @@ class CAA extends RR {
     if (typeof val !== 'string'
       || val.length < 1
       || /[^a-z0-9]/.test(val))
-      throw new Error(`CAA tag must be a sequence of ASCII letters and numbers in lowercase, RFC ${this.getRFCs()}`)
+      throw new Error(`CAA tag must be a sequence of ASCII letters and numbers in lowercase, ${this.citeRFC()}`)
 
     if (![ 'issue', 'issuewild', 'iodef' ].includes(val)) {
-      throw new Error(`CAA tag ${val} not recognized: ${this.getRFCs()}`)
+      throw new Error(`CAA tag ${val} not recognized: ${this.citeRFC()}`)
     }
     this.set('tag', val)
   }
@@ -43,7 +43,7 @@ class CAA extends RR {
     // check if val starts with one of iodefSchemes
     const iodefSchemes = [ 'mailto:', 'http:', 'https:' ]
     if (!iodefSchemes.filter(s => val.startsWith(s)).length) {
-      throw new Error(`CAA value must have valid iodefScheme prefix, RFC ${this.getRFCs()}`)
+      throw new Error(`CAA value must have valid iodefScheme prefix, ${this.citeRFC()}`)
     }
 
     this.set('value', val)

--- a/rr/caa.js
+++ b/rr/caa.js
@@ -12,7 +12,7 @@ class CAA extends RR {
     this.is8bitInt('CAA', 'flags', val)
 
     if (![ 0, 128 ].includes(val)) {
-      throw new Error(`CAA flags ${val} not recognized: ${this.getRFCs()}`)
+      throw new Error(`CAA flags ${val} not recognized, RFC ${this.getRFCs()}`)
     }
 
     this.set('flags', val)
@@ -22,7 +22,7 @@ class CAA extends RR {
     if (typeof val !== 'string'
       || val.length < 1
       || /[^a-z0-9]/.test(val))
-      throw new Error(`CAA tag must be a sequence of ASCII letters and numbers in lowercase: ${this.getRFCs()}`)
+      throw new Error(`CAA tag must be a sequence of ASCII letters and numbers in lowercase, RFC ${this.getRFCs()}`)
 
     if (![ 'issue', 'issuewild', 'iodef' ].includes(val)) {
       throw new Error(`CAA tag ${val} not recognized: ${this.getRFCs()}`)
@@ -43,7 +43,7 @@ class CAA extends RR {
     // check if val starts with one of iodefSchemes
     const iodefSchemes = [ 'mailto:', 'http:', 'https:' ]
     if (!iodefSchemes.filter(s => val.startsWith(s)).length) {
-      throw new Error(`CAA value must have valid iodefScheme prefix: ${this.getRFCs()}`)
+      throw new Error(`CAA value must have valid iodefScheme prefix, RFC ${this.getRFCs()}`)
     }
 
     this.set('value', val)

--- a/rr/dname.js
+++ b/rr/dname.js
@@ -13,7 +13,7 @@ class DNAME extends RR {
     if (!val) throw new Error('DNAME: target is required')
 
     if (net.isIPv4(val) || net.isIPv6(val))
-      throw new Error(`DNAME: target must be a domain name, RFC ${this.getRFCs()}`)
+      throw new Error(`DNAME: target must be a domain name, ${this.citeRFC()}`)
 
     this.isFullyQualified('DNAME', 'target', val)
     this.isValidHostname('DNAME', 'target', val)

--- a/rr/dname.js
+++ b/rr/dname.js
@@ -13,7 +13,7 @@ class DNAME extends RR {
     if (!val) throw new Error('DNAME: target is required')
 
     if (net.isIPv4(val) || net.isIPv6(val))
-      throw new Error(`DNAME: target must be a domain name: RFC 6672`)
+      throw new Error(`DNAME: target must be a domain name, RFC ${this.getRFCs()}`)
 
     this.isFullyQualified('DNAME', 'target', val)
     this.isValidHostname('DNAME', 'target', val)

--- a/rr/dnskey.js
+++ b/rr/dnskey.js
@@ -10,7 +10,7 @@ class DNSKEY extends RR {
   setFlags (val) {
     // a 2 octet Flags Field
     // the possible values are: 0, 256, and 257 RFC 4034
-    if (![ 0, 256, 257 ].includes(val)) throw new Error(`DNSKEY: flags invalid, see ${this.getRFCs()}`)
+    if (![ 0, 256, 257 ].includes(val)) throw new Error(`DNSKEY: flags invalid, see RFC ${this.getRFCs()}`)
 
     this.set('flags', val)
   }
@@ -18,7 +18,7 @@ class DNSKEY extends RR {
   setProtocol (val) {
     // 1 octet
     // The Protocol Field MUST be represented as an unsigned decimal integer with a value of 3.
-    if (![ 3 ].includes(val)) throw new Error(`DNSKEY: protocol invalid, see ${this.getRFCs()}`)
+    if (![ 3 ].includes(val)) throw new Error(`DNSKEY: protocol invalid, see RFC ${this.getRFCs()}`)
 
     this.set('protocol', val)
   }
@@ -27,13 +27,13 @@ class DNSKEY extends RR {
     // 1 octet
     // 1=RSA/MD5, 2=DH, 3=DSA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![ 1,2,3,4,5,253,254 ].includes(val))
-      throw new Error(`DNSKEY: algorithm invalid, see ${this.getRFCs()}`)
+      throw new Error(`DNSKEY: algorithm invalid, see RFC ${this.getRFCs()}`)
 
     this.set('algorithm', val)
   }
 
   setPublickey (val) {
-    if (!val) throw new Error(`DNSKEY: publickey is required, see ${this.getRFCs()}`)
+    if (!val) throw new Error(`DNSKEY: publickey is required, see RFC ${this.getRFCs()}`)
 
     this.set('publickey', val)
   }

--- a/rr/dnskey.js
+++ b/rr/dnskey.js
@@ -10,7 +10,7 @@ class DNSKEY extends RR {
   setFlags (val) {
     // a 2 octet Flags Field
     // the possible values are: 0, 256, and 257 RFC 4034
-    if (![ 0, 256, 257 ].includes(val)) throw new Error(`DNSKEY: flags invalid, see RFC ${this.getRFCs()}`)
+    if (![ 0, 256, 257 ].includes(val)) throw new Error(`DNSKEY: flags invalid, ${this.citeRFC()}`)
 
     this.set('flags', val)
   }
@@ -18,7 +18,7 @@ class DNSKEY extends RR {
   setProtocol (val) {
     // 1 octet
     // The Protocol Field MUST be represented as an unsigned decimal integer with a value of 3.
-    if (![ 3 ].includes(val)) throw new Error(`DNSKEY: protocol invalid, see RFC ${this.getRFCs()}`)
+    if (![ 3 ].includes(val)) throw new Error(`DNSKEY: protocol invalid, ${this.citeRFC()}`)
 
     this.set('protocol', val)
   }
@@ -27,13 +27,13 @@ class DNSKEY extends RR {
     // 1 octet
     // 1=RSA/MD5, 2=DH, 3=DSA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![ 1,2,3,4,5,253,254 ].includes(val))
-      throw new Error(`DNSKEY: algorithm invalid, see RFC ${this.getRFCs()}`)
+      throw new Error(`DNSKEY: algorithm invalid, ${this.citeRFC()}`)
 
     this.set('algorithm', val)
   }
 
   setPublickey (val) {
-    if (!val) throw new Error(`DNSKEY: publickey is required, see RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`DNSKEY: publickey is required, ${this.citeRFC()}`)
 
     this.set('publickey', val)
   }

--- a/rr/ds.js
+++ b/rr/ds.js
@@ -10,7 +10,7 @@ class DS extends RR {
   setKeyTag (val) {
     // a 2 octet Key Tag field...in network byte order
     if (!val) throw new Error(`DS: key tag is required`)
-    if (val.length > 2) throw new Error(`DS: key tag is too long, see ${this.getRFCs()}`)
+    if (val.length > 2) throw new Error(`DS: key tag is too long, see RFC ${this.getRFCs()}`)
 
     this.set('key tag', val)
   }
@@ -18,19 +18,19 @@ class DS extends RR {
   setAlgorithm (val) {
     // 1=RSA/MD5, 2=DH, 3=DSA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![ 1,2,3,4,5,253,254 ].includes(val))
-      throw new Error(`DS: algorithm invalid, see ${this.getRFCs()}`)
+      throw new Error(`DS: algorithm invalid, see RFC ${this.getRFCs()}`)
 
     this.set('algorithm', val)
   }
 
   setDigestType (val) {
-    if (![ 1,2 ].includes(val)) throw new Error(`DS: digest type invalid, see ${this.getRFCs()}`)
+    if (![ 1,2 ].includes(val)) throw new Error(`DS: digest type invalid, see RFC ${this.getRFCs()}`)
 
     this.set('digest type', val)
   }
 
   setDigest (val) {
-    if (!val) throw new Error(`DS: digest is required, see ${this.getRFCs()}`)
+    if (!val) throw new Error(`DS: digest is required, see RFC ${this.getRFCs()}`)
 
     this.set('digest', val)
   }

--- a/rr/ds.js
+++ b/rr/ds.js
@@ -10,7 +10,7 @@ class DS extends RR {
   setKeyTag (val) {
     // a 2 octet Key Tag field...in network byte order
     if (!val) throw new Error(`DS: key tag is required`)
-    if (val.length > 2) throw new Error(`DS: key tag is too long, see RFC ${this.getRFCs()}`)
+    if (val.length > 2) throw new Error(`DS: key tag is too long, ${this.citeRFC()}`)
 
     this.set('key tag', val)
   }
@@ -18,19 +18,19 @@ class DS extends RR {
   setAlgorithm (val) {
     // 1=RSA/MD5, 2=DH, 3=DSA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![ 1,2,3,4,5,253,254 ].includes(val))
-      throw new Error(`DS: algorithm invalid, see RFC ${this.getRFCs()}`)
+      throw new Error(`DS: algorithm invalid, ${this.citeRFC()}`)
 
     this.set('algorithm', val)
   }
 
   setDigestType (val) {
-    if (![ 1,2 ].includes(val)) throw new Error(`DS: digest type invalid, see RFC ${this.getRFCs()}`)
+    if (![ 1,2 ].includes(val)) throw new Error(`DS: digest type invalid, ${this.citeRFC()}`)
 
     this.set('digest type', val)
   }
 
   setDigest (val) {
-    if (!val) throw new Error(`DS: digest is required, see RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`DS: digest is required, ${this.citeRFC()}`)
 
     this.set('digest', val)
   }

--- a/rr/index.js
+++ b/rr/index.js
@@ -264,7 +264,7 @@ class RR extends Map {
   }
 
   isValidHostname (type, field, hostname) {
-    if (!/[^a-zA-Z0-9\-._/]/.test(hostname)) return true
+    if (!/[^a-zA-Z0-9\-._/\\]/.test(hostname)) return true
     throw new Error(`${type}, ${field} has invalid hostname characters`)
   }
 

--- a/rr/index.js
+++ b/rr/index.js
@@ -127,7 +127,7 @@ class RR extends Map {
     if (zone_opts.hide?.ttl && rrTTL === zone_opts.ttl) rrTTL = ''
 
     let owner = this.get('owner')
-    if (zone_opts.hide?.sameOwner && zone_opts.previousName === owner) {
+    if (zone_opts.hide?.sameOwner && zone_opts.previousOwner === owner) {
       owner = ''
     }
     else {

--- a/rr/index.js
+++ b/rr/index.js
@@ -112,6 +112,10 @@ class RR extends Map {
     this.set('type', t)
   }
 
+  citeRFC () {
+    return `see RFC ${this.getRFCs()}`
+  }
+
   fullyQualify (hostname, origin) {
     if (!hostname) return hostname
     if (hostname === '@' && origin) hostname = origin
@@ -301,7 +305,8 @@ for (let f of files) {
   f = path.basename(f, '.js')
   if (f === 'index') continue
   const rrTypeName = f.toUpperCase()
-  module.exports[rrTypeName] = require(`./${f}`)
-  const inst = new module.exports[rrTypeName](null)
-  module.exports.TYPE_MAP[inst.getTypeId()] = rrTypeName
+  const rrmod = require(`./${f}`)
+  module.exports[rrTypeName] = rrmod
+  // const inst = new rrmod(null)
+  // module.exports.TYPE_MAP[inst.getTypeId()] = rrTypeName
 }

--- a/rr/key.js
+++ b/rr/key.js
@@ -25,13 +25,13 @@ class KEY extends RR {
     // 1 octet
     // 1=RSA/MD5, 2=DH, 3=DSA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![ 1,2,3,4,5,253,254 ].includes(val))
-      throw new Error(`KEY: algorithm invalid, see RFC ${this.getRFCs()}`)
+      throw new Error(`KEY: algorithm invalid, ${this.citeRFC()}`)
 
     this.set('algorithm', val)
   }
 
   setPublickey (val) {
-    if (!val) throw new Error(`KEY: publickey is required, see RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`KEY: publickey is required, ${this.citeRFC()}`)
 
     this.set('publickey', val)
   }

--- a/rr/key.js
+++ b/rr/key.js
@@ -25,13 +25,13 @@ class KEY extends RR {
     // 1 octet
     // 1=RSA/MD5, 2=DH, 3=DSA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![ 1,2,3,4,5,253,254 ].includes(val))
-      throw new Error(`KEY: algorithm invalid, see ${this.getRFCs()}`)
+      throw new Error(`KEY: algorithm invalid, see RFC ${this.getRFCs()}`)
 
     this.set('algorithm', val)
   }
 
   setPublickey (val) {
-    if (!val) throw new Error(`KEY: publickey is required, see ${this.getRFCs()}`)
+    if (!val) throw new Error(`KEY: publickey is required, see RFC ${this.getRFCs()}`)
 
     this.set('publickey', val)
   }

--- a/rr/mx.js
+++ b/rr/mx.js
@@ -19,7 +19,7 @@ class MX extends RR {
     if (!val) throw new Error('MX: exchange is required')
 
     if (net.isIPv4(val) || net.isIPv6(val))
-      throw new Error(`MX: exchange must be a FQDN, RFC ${this.getRFCs()}`)
+      throw new Error(`MX: exchange must be a FQDN, ${this.citeRFC()}`)
 
     this.isFullyQualified('MX', 'exchange', val)
     this.isValidHostname('MX', 'exchange', val)

--- a/rr/mx.js
+++ b/rr/mx.js
@@ -19,7 +19,7 @@ class MX extends RR {
     if (!val) throw new Error('MX: exchange is required')
 
     if (net.isIPv4(val) || net.isIPv6(val))
-      throw new Error(`MX: exchange must be a FQDN: ${this.getRFCs()}`)
+      throw new Error(`MX: exchange must be a FQDN, RFC ${this.getRFCs()}`)
 
     this.isFullyQualified('MX', 'exchange', val)
     this.isValidHostname('MX', 'exchange', val)

--- a/rr/naptr.js
+++ b/rr/naptr.js
@@ -42,7 +42,7 @@ class NAPTR extends RR {
 
   setFlags (val) {
     if (![ '', 'S', 'A', 'U', 'P' ].includes(val))
-      throw new Error (`NAPTR flags are invalid: ${this.getRFCs()}`)
+      throw new Error (`NAPTR flags are invalid, RFC: ${this.getRFCs()}`)
 
     this.set('flags', val)
   }
@@ -75,11 +75,11 @@ class NAPTR extends RR {
       preference: TINYDNS.octalToUInt16(rdata.substr(8, 8)),
     }
     /*
-  TODO: incomplete, need to remove octal escapes from regexp
-'cid.urn.arpa\t86400\tIN\tNAPTR\t100\t10\t""\t""\t"!^urn:cid:.+@([^\\.]+\\.)(.*)$!\x02!i"\t.\n',
-':cid.urn.arpa:35:
-\000\144\000\012\000\000\040!^urn\072cid\072.+@([^\134.]+\134.)(.*)$!\x02!i\001.``000:86400::'
-*/
+    TODO: incomplete, need to remove octal escapes from regexp
+    'cid.urn.arpa\t86400\tIN\tNAPTR\t100\t10\t""\t""\t"!^urn:cid:.+@([^\\.]+\\.)(.*)$!\x02!i"\t.\n',
+    ':cid.urn.arpa:35:
+    \000\144\000\012\000\000\040!^urn\072cid\072.+@([^\134.]+\134.)(.*)$!\x02!i\001.``000:86400::'
+    */
 
     let idx = 16
     const flagsLength = TINYDNS.octalToUInt8(rdata.substr(idx, 4))

--- a/rr/naptr.js
+++ b/rr/naptr.js
@@ -42,7 +42,7 @@ class NAPTR extends RR {
 
   setFlags (val) {
     if (![ '', 'S', 'A', 'U', 'P' ].includes(val))
-      throw new Error (`NAPTR flags are invalid, RFC: ${this.getRFCs()}`)
+      throw new Error (`NAPTR flags are invalid, ${this.citeRFC()}`)
 
     this.set('flags', val)
   }

--- a/rr/ns.js
+++ b/rr/ns.js
@@ -9,7 +9,7 @@ class NS extends RR {
 
   /****** Resource record specific setters   *******/
   setDname (val) {
-    if (!val) throw new Error(`NS: dname is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NS: dname is required, RFC ${this.getRFCs()}`)
 
     this.isFullyQualified('NS', 'dname', val)
     this.isValidHostname('NS', 'dname', val)

--- a/rr/ns.js
+++ b/rr/ns.js
@@ -9,7 +9,7 @@ class NS extends RR {
 
   /****** Resource record specific setters   *******/
   setDname (val) {
-    if (!val) throw new Error(`NS: dname is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NS: dname is required, ${this.citeRFC()}`)
 
     this.isFullyQualified('NS', 'dname', val)
     this.isValidHostname('NS', 'dname', val)

--- a/rr/nsec.js
+++ b/rr/nsec.js
@@ -9,7 +9,7 @@ class NSEC extends RR {
 
   /****** Resource record specific setters   *******/
   setNextDomain (val) {
-    if (!val) throw new Error(`NSEC: 'next domain' is required:, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC: 'next domain' is required:, ${this.citeRFC()}`)
 
     this.isFullyQualified('NSEC', 'next domain', val)
     this.isValidHostname('NSEC', 'next domain', val)
@@ -19,7 +19,7 @@ class NSEC extends RR {
   }
 
   setTypeBitMaps (val) {
-    if (!val) throw new Error(`NSEC: 'type bit maps' is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC: 'type bit maps' is required, ${this.citeRFC()}`)
 
     this.set('type bit maps', val)
   }

--- a/rr/nsec.js
+++ b/rr/nsec.js
@@ -9,7 +9,7 @@ class NSEC extends RR {
 
   /****** Resource record specific setters   *******/
   setNextDomain (val) {
-    if (!val) throw new Error(`NSEC: 'next domain' is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC: 'next domain' is required:, RFC ${this.getRFCs()}`)
 
     this.isFullyQualified('NSEC', 'next domain', val)
     this.isValidHostname('NSEC', 'next domain', val)
@@ -19,7 +19,7 @@ class NSEC extends RR {
   }
 
   setTypeBitMaps (val) {
-    if (!val) throw new Error(`NSEC: 'type bit maps' is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC: 'type bit maps' is required, RFC ${this.getRFCs()}`)
 
     this.set('type bit maps', val)
   }

--- a/rr/nsec3.js
+++ b/rr/nsec3.js
@@ -11,7 +11,7 @@ class NSEC3 extends RR {
   setHashAlgoritm (val) {
     // Hash Algorithm is a single octet.
     // The Hash Algorithm field is represented as an unsigned decimal integer.
-    if (!val) throw new Error(`NSEC3: 'hash algorithm' is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3: 'hash algorithm' is required, ${this.citeRFC()}`)
 
     this.is8bitInt(val)
 
@@ -20,7 +20,7 @@ class NSEC3 extends RR {
 
   setFlags (val) {
     // The Flags field is represented as an unsigned decimal integer.
-    if (!val) throw new Error(`NSEC3: 'flags' is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3: 'flags' is required, ${this.citeRFC()}`)
 
     this.is8bitInt(val)
 
@@ -29,7 +29,7 @@ class NSEC3 extends RR {
 
   setIterations (val) {
     // The Iterations field is represented as an unsigned decimal integer. 0-65535
-    if (!val) throw new Error(`NSEC3: 'iterations' is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3: 'iterations' is required, ${this.citeRFC()}`)
 
     this.is16bitInt(val)
 
@@ -47,14 +47,14 @@ class NSEC3 extends RR {
   setNextHashedOwnerName (val) {
     // The Next Hashed Owner Name field is represented as an unpadded
     // sequence of case-insensitive base32 digits, without whitespace
-    if (!val) throw new Error(`NSEC3: 'next hashed owner name' is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3: 'next hashed owner name' is required, ${this.citeRFC()}`)
 
     this.set('next hashed owner name', val)
   }
 
   setTypeBitMaps (val) {
     // The Type Bit Maps field is represented as a sequence of RR type mnemonics.
-    if (!val) throw new Error(`NSEC3: 'type bit maps' is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3: 'type bit maps' is required, ${this.citeRFC()}`)
 
     this.set('type bit maps', val)
   }

--- a/rr/nsec3.js
+++ b/rr/nsec3.js
@@ -11,7 +11,7 @@ class NSEC3 extends RR {
   setHashAlgoritm (val) {
     // Hash Algorithm is a single octet.
     // The Hash Algorithm field is represented as an unsigned decimal integer.
-    if (!val) throw new Error(`NSEC3: 'hash algorithm' is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3: 'hash algorithm' is required, RFC ${this.getRFCs()}`)
 
     this.is8bitInt(val)
 
@@ -20,7 +20,7 @@ class NSEC3 extends RR {
 
   setFlags (val) {
     // The Flags field is represented as an unsigned decimal integer.
-    if (!val) throw new Error(`NSEC3: 'flags' is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3: 'flags' is required, RFC ${this.getRFCs()}`)
 
     this.is8bitInt(val)
 
@@ -29,7 +29,7 @@ class NSEC3 extends RR {
 
   setIterations (val) {
     // The Iterations field is represented as an unsigned decimal integer. 0-65535
-    if (!val) throw new Error(`NSEC3: 'iterations' is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3: 'iterations' is required, RFC ${this.getRFCs()}`)
 
     this.is16bitInt(val)
 
@@ -47,14 +47,14 @@ class NSEC3 extends RR {
   setNextHashedOwnerName (val) {
     // The Next Hashed Owner Name field is represented as an unpadded
     // sequence of case-insensitive base32 digits, without whitespace
-    if (!val) throw new Error(`NSEC3: 'next hashed owner name' is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3: 'next hashed owner name' is required, RFC ${this.getRFCs()}`)
 
     this.set('next hashed owner name', val)
   }
 
   setTypeBitMaps (val) {
     // The Type Bit Maps field is represented as a sequence of RR type mnemonics.
-    if (!val) throw new Error(`NSEC3: 'type bit maps' is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3: 'type bit maps' is required, RFC ${this.getRFCs()}`)
 
     this.set('type bit maps', val)
   }

--- a/rr/nsec3param.js
+++ b/rr/nsec3param.js
@@ -11,7 +11,7 @@ class NSEC3PARAM extends RR {
   setHashAlgoritm (val) {
     // Hash Algorithm is a single octet.
     // The Hash Algorithm field is represented as an unsigned decimal integer.
-    if (!val) throw new Error(`NSEC3PARAM: 'hash algorithm' is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3PARAM: 'hash algorithm' is required, RFC ${this.getRFCs()}`)
 
     this.is8bitInt(val)
 
@@ -20,7 +20,7 @@ class NSEC3PARAM extends RR {
 
   setFlags (val) {
     // The Flags field is represented as an unsigned decimal integer.
-    if (!val) throw new Error(`NSEC3PARAM: 'flags' is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3PARAM: 'flags' is required, RFC ${this.getRFCs()}`)
 
     this.is8bitInt(val)
 
@@ -29,7 +29,7 @@ class NSEC3PARAM extends RR {
 
   setIterations (val) {
     // The Iterations field is represented as an unsigned decimal integer. 0-65535
-    if (!val) throw new Error(`NSEC3PARAM: 'iterations' is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3PARAM: 'iterations' is required, RFC ${this.getRFCs()}`)
 
     this.is16bitInt(val)
 

--- a/rr/nsec3param.js
+++ b/rr/nsec3param.js
@@ -11,7 +11,7 @@ class NSEC3PARAM extends RR {
   setHashAlgoritm (val) {
     // Hash Algorithm is a single octet.
     // The Hash Algorithm field is represented as an unsigned decimal integer.
-    if (!val) throw new Error(`NSEC3PARAM: 'hash algorithm' is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3PARAM: 'hash algorithm' is required, ${this.citeRFC()}`)
 
     this.is8bitInt(val)
 
@@ -20,7 +20,7 @@ class NSEC3PARAM extends RR {
 
   setFlags (val) {
     // The Flags field is represented as an unsigned decimal integer.
-    if (!val) throw new Error(`NSEC3PARAM: 'flags' is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3PARAM: 'flags' is required, ${this.citeRFC()}`)
 
     this.is8bitInt(val)
 
@@ -29,7 +29,7 @@ class NSEC3PARAM extends RR {
 
   setIterations (val) {
     // The Iterations field is represented as an unsigned decimal integer. 0-65535
-    if (!val) throw new Error(`NSEC3PARAM: 'iterations' is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`NSEC3PARAM: 'iterations' is required, ${this.citeRFC()}`)
 
     this.is16bitInt(val)
 

--- a/rr/rrsig.js
+++ b/rr/rrsig.js
@@ -10,7 +10,7 @@ class RRSIG extends RR {
   setTypeCovered (val) {
     // a 2 octet Type Covered field
     if (!val) throw new Error(`RRSIG: 'type covered' is required`)
-    if (val.length > 2) throw new Error(`RRSIG: 'type covered' is too long, see ${this.getRFCs()}`)
+    if (val.length > 2) throw new Error(`RRSIG: 'type covered' is too long, see RFC ${this.getRFCs()}`)
 
     this.set('type covered', val)
   }
@@ -19,7 +19,7 @@ class RRSIG extends RR {
     // a 1 octet Algorithm field
     // 1=RSA/MD5, 2=DH, 3=RRSIGA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![ 1,2,3,4,5,253,254 ].includes(val))
-      throw new Error(`RRSIG: algorithm invalid, see ${this.getRFCs()}`)
+      throw new Error(`RRSIG: algorithm invalid, see RFC ${this.getRFCs()}`)
 
     this.set('algorithm', val)
   }

--- a/rr/rrsig.js
+++ b/rr/rrsig.js
@@ -10,7 +10,7 @@ class RRSIG extends RR {
   setTypeCovered (val) {
     // a 2 octet Type Covered field
     if (!val) throw new Error(`RRSIG: 'type covered' is required`)
-    if (val.length > 2) throw new Error(`RRSIG: 'type covered' is too long, see RFC ${this.getRFCs()}`)
+    if (val.length > 2) throw new Error(`RRSIG: 'type covered' is too long, ${this.citeRFC()}`)
 
     this.set('type covered', val)
   }
@@ -19,7 +19,7 @@ class RRSIG extends RR {
     // a 1 octet Algorithm field
     // 1=RSA/MD5, 2=DH, 3=RRSIGA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![ 1,2,3,4,5,253,254 ].includes(val))
-      throw new Error(`RRSIG: algorithm invalid, see RFC ${this.getRFCs()}`)
+      throw new Error(`RRSIG: algorithm invalid, ${this.citeRFC()}`)
 
     this.set('algorithm', val)
   }

--- a/rr/smimea.js
+++ b/rr/smimea.js
@@ -9,21 +9,21 @@ class SMIMEA extends RR {
   /****** Resource record specific setters   *******/
   setCertificateUsage (val) {
     if (![ 0,1,2,3 ].includes(val))
-      throw new Error(`SMIMEA: certificate usage invalid, see RFC ${this.getRFCs()}`)
+      throw new Error(`SMIMEA: certificate usage invalid, ${this.citeRFC()}`)
 
     this.set('certificate usage', val)
   }
 
   setSelector (val) {
     if (![ 0,1 ].includes(val))
-      throw new Error(`SMIMEA: selector invalid, see RFC ${this.getRFCs()}`)
+      throw new Error(`SMIMEA: selector invalid, ${this.citeRFC()}`)
 
     this.set('selector', val)
   }
 
   setMatchingType (val) {
     if (![ 0,1,2 ].includes(val))
-      throw new Error(`SMIMEA: matching type, see RFC ${this.getRFCs()}`)
+      throw new Error(`SMIMEA: matching type, ${this.citeRFC()}`)
 
     this.set('matching type', val)
   }

--- a/rr/smimea.js
+++ b/rr/smimea.js
@@ -9,21 +9,21 @@ class SMIMEA extends RR {
   /****** Resource record specific setters   *******/
   setCertificateUsage (val) {
     if (![ 0,1,2,3 ].includes(val))
-      throw new Error(`SMIMEA: certificate usage invalid, see ${this.getRFCs()}`)
+      throw new Error(`SMIMEA: certificate usage invalid, see RFC ${this.getRFCs()}`)
 
     this.set('certificate usage', val)
   }
 
   setSelector (val) {
     if (![ 0,1 ].includes(val))
-      throw new Error(`SMIMEA: selector invalid, see ${this.getRFCs()}`)
+      throw new Error(`SMIMEA: selector invalid, see RFC ${this.getRFCs()}`)
 
     this.set('selector', val)
   }
 
   setMatchingType (val) {
     if (![ 0,1,2 ].includes(val))
-      throw new Error(`SMIMEA: matching type, see ${this.getRFCs()}`)
+      throw new Error(`SMIMEA: matching type, see RFC ${this.getRFCs()}`)
 
     this.set('matching type', val)
   }

--- a/rr/soa.js
+++ b/rr/soa.js
@@ -29,7 +29,7 @@ class SOA extends RR {
     // RNAME (email of admin)  (escape . with \)
     this.isValidHostname('SOA', 'RNAME', val)
     this.isFullyQualified('SOA', 'RNAME', val)
-    if (/@/.test(val)) throw new Error(`SOA rname replaces @ with a . (dot), ${this.getRFCs()}`)
+    if (/@/.test(val)) throw new Error(`SOA rname replaces @ with a . (dot), ${this.citeRFC()}`)
 
     // RFC 4034: letters in the DNS names are lower cased
     this.set('rname', val.toLowerCase())

--- a/rr/soa.js
+++ b/rr/soa.js
@@ -140,6 +140,10 @@ ${numFields.map(f => '\t\t' + this.get(f) + this.getComment(f) + '\n').join('')}
 \n`
   }
 
+  toMaraDNS () {
+    return `${this.get('owner')}\t SOA\t${this.getRdataFields().map(f => this.getQuoted(f)).join('\t')} ~\n`
+  }
+
   toTinydns () {
     return `Z${this.getTinyFQDN('owner')}:${this.getTinyFQDN('mname')}:${this.getTinyFQDN('rname')}:${this.getEmpty('serial')}:${this.getEmpty('refresh')}:${this.getEmpty('retry')}:${this.getEmpty('expire')}:${this.getEmpty('minimum')}:${this.getTinydnsPostamble()}\n`
   }

--- a/rr/srv.js
+++ b/rr/srv.js
@@ -29,10 +29,10 @@ class SRV extends RR {
   }
 
   setTarget (val) {
-    if (!val) throw new Error(`SRV: target is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`SRV: target is required, ${this.citeRFC()}`)
 
     if (net.isIPv4(val) || net.isIPv6(val))
-      throw new Error(`SRV: target must be a FQDN, RFC ${this.getRFCs()}`)
+      throw new Error(`SRV: target must be a FQDN, ${this.citeRFC()}`)
 
     this.isFullyQualified('SRV', 'target', val)
     this.isValidHostname('SRV', 'target', val)

--- a/rr/srv.js
+++ b/rr/srv.js
@@ -29,10 +29,10 @@ class SRV extends RR {
   }
 
   setTarget (val) {
-    if (!val) throw new Error(`SRV: target is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`SRV: target is required, RFC ${this.getRFCs()}`)
 
     if (net.isIPv4(val) || net.isIPv6(val))
-      throw new Error(`SRV: target must be a FQDN: ${this.getRFCs()}`)
+      throw new Error(`SRV: target must be a FQDN, RFC ${this.getRFCs()}`)
 
     this.isFullyQualified('SRV', 'target', val)
     this.isValidHostname('SRV', 'target', val)

--- a/rr/tlsa.js
+++ b/rr/tlsa.js
@@ -9,21 +9,21 @@ class TLSA extends RR {
   /****** Resource record specific setters   *******/
   setCertificateUsage (val) {
     if (![ 0,1,2,3 ].includes(val))
-      throw new Error(`TLSA: certificate usage invalid, see ${this.getRFCs()}`)
+      throw new Error(`TLSA: certificate usage invalid, see RFC ${this.getRFCs()}`)
 
     this.set('certificate usage', val)
   }
 
   setSelector (val) {
     if (![ 0,1 ].includes(val))
-      throw new Error(`TLSA: selector invalid, see ${this.getRFCs()}`)
+      throw new Error(`TLSA: selector invalid, see RFC ${this.getRFCs()}`)
 
     this.set('selector', val)
   }
 
   setMatchingType (val) {
     if (![ 0,1,2 ].includes(val))
-      throw new Error(`TLSA: matching type, see ${this.getRFCs()}`)
+      throw new Error(`TLSA: matching type, see RFC ${this.getRFCs()}`)
 
     this.set('matching type', val)
   }

--- a/rr/tlsa.js
+++ b/rr/tlsa.js
@@ -9,21 +9,21 @@ class TLSA extends RR {
   /****** Resource record specific setters   *******/
   setCertificateUsage (val) {
     if (![ 0,1,2,3 ].includes(val))
-      throw new Error(`TLSA: certificate usage invalid, see RFC ${this.getRFCs()}`)
+      throw new Error(`TLSA: certificate usage invalid, ${this.citeRFC()}`)
 
     this.set('certificate usage', val)
   }
 
   setSelector (val) {
     if (![ 0,1 ].includes(val))
-      throw new Error(`TLSA: selector invalid, see RFC ${this.getRFCs()}`)
+      throw new Error(`TLSA: selector invalid, ${this.citeRFC()}`)
 
     this.set('selector', val)
   }
 
   setMatchingType (val) {
     if (![ 0,1,2 ].includes(val))
-      throw new Error(`TLSA: matching type, see RFC ${this.getRFCs()}`)
+      throw new Error(`TLSA: matching type, ${this.citeRFC()}`)
 
     this.set('matching type', val)
   }

--- a/rr/txt.js
+++ b/rr/txt.js
@@ -83,8 +83,7 @@ class TXT extends RR {
 
   /******  EXPORTERS   *******/
   toBind (zone_opts) {
-    const data = asQuotedStrings(this.get('data'))
-    return `${this.getPrefix(zone_opts)}\t"${data}"\n`
+    return `${this.getPrefix(zone_opts)}\t"${asQuotedStrings(this.get('data'))}"\n`
   }
 
   toMaraDNS () {
@@ -114,6 +113,8 @@ function asQuotedStrings (data) {
   if (data.length > 255) {
     return data.match(/(.{1,255})/g).join('" "')
   }
+
+  return data
 }
 
 module.exports = TXT

--- a/rr/txt.js
+++ b/rr/txt.js
@@ -83,24 +83,13 @@ class TXT extends RR {
 
   /******  EXPORTERS   *******/
   toBind (zone_opts) {
-    let data = this.get('data')
-
-    // BIND croaks when any string in the TXT RR data is longer than 255
-    if (Array.isArray(data)) {
-      let hasTooLong = false
-      for (const str of data) {
-        if (str.length > 255) hasTooLong = true
-      }
-      data = hasTooLong ? data.join('').match(/(.{1,255})/g).join('" "') : data.join('" "')
-    }
-    else {
-      if (data.length > 255) {
-        // BIND croaks when any string in the TXT RR data is longer than 255
-        data = data.match(/(.{1,255})/g).join('" "')
-      }
-    }
-
+    const data = asQuotedStrings(this.get('data'))
     return `${this.getPrefix(zone_opts)}\t"${data}"\n`
+  }
+
+  toMaraDNS () {
+    const data = asQuotedStrings(this.get('data')).replace(/"/g, "'")
+    return `${this.get('owner')}\t+${this.get('ttl')}\t${this.get('type')}\t'${data}' ~\n`
   }
 
   toTinydns () {
@@ -108,6 +97,22 @@ class TXT extends RR {
     if (Array.isArray(data)) data = data.join('')
     const rdata = TINYDNS.escapeOctal(new RegExp(/[\r\n\t:\\/]/, 'g'), data)
     return `'${this.getTinyFQDN('owner')}:${rdata}:${this.getTinydnsPostamble()}\n`
+  }
+}
+
+function asQuotedStrings (data) {
+
+  // BIND croaks when any string in the TXT RR data is longer than 255
+  if (Array.isArray(data)) {
+    let hasTooLong = false
+    for (const str of data) {
+      if (str.length > 255) hasTooLong = true
+    }
+    return hasTooLong ? data.join('').match(/(.{1,255})/g).join('" "') : data.join('" "')
+  }
+
+  if (data.length > 255) {
+    return data.match(/(.{1,255})/g).join('" "')
   }
 }
 

--- a/rr/uri.js
+++ b/rr/uri.js
@@ -21,7 +21,7 @@ class URI extends RR {
   }
 
   setTarget (val) {
-    if (!val) throw new Error(`URI: target is required, RFC ${this.getRFCs()}`)
+    if (!val) throw new Error(`URI: target is required, ${this.citeRFC()}`)
 
     this.set('target', val)
   }

--- a/rr/uri.js
+++ b/rr/uri.js
@@ -21,7 +21,7 @@ class URI extends RR {
   }
 
   setTarget (val) {
-    if (!val) throw new Error(`URI: target is required: ${this.getRFCs()}`)
+    if (!val) throw new Error(`URI: target is required, RFC ${this.getRFCs()}`)
 
     this.set('target', val)
   }


### PR DESCRIPTION
- index
    - previousName -> previousOwner
    - export a TYPE_MAP (id => name)
- isValidHostname: allow \ char
- add the word 'RFC' in error messages citing RFCs
- when rejecting hostname, show the rejected character
- maradns: add export support
