### PR TITLE
feat: add SVCB record support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable changes to this project are documented in this file.
 
 #### Unreleased
 
+- feat(SVCB,HTTPS): add record support
+
 ### [1.2.0] - 2024-03-07
 
 - feat(index): export typeMap (lookup table for type to id)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DNS resource record parser, validator, importer, and exporter.
 This module is used to:
 
 - validate well formedness and RFC compliance of DNS resource records
-- import RRs from and from the following formats:
+- import RRs to and from the following formats:
 
 |                      **RR format**                       |     **import**     |     **export**     |
 | :------------------------------------------------------: | :----------------: | :----------------: |
@@ -196,6 +196,7 @@ PRs are welcome, especially PRs with tests.
 |   **DNSKEY**   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 |     **DS**     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 |   **HINFO**    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|   **HTTPS**    |                    |                    |                    |                    |
 |  **IPSECKEY**  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 |    **KEY**     |                    |                    |                    |                    |
 |    **LOC**     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
@@ -215,6 +216,7 @@ PRs are welcome, especially PRs with tests.
 |    **SPF**     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 |    **SRV**     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 |   **SSHFP**    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|    **SVCB**    |                    |                    |                    |                    |
 |    **TLSA**    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 |    **TSIG**    |                    |                    |                    |                    |
 |    **TXT**     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ import SOA from './rr/soa.js'
 import SPF from './rr/spf.js'
 import SRV from './rr/srv.js'
 import SSHFP from './rr/sshfp.js'
+import SVCB from './rr/svcb.js'
 import TLSA from './rr/tlsa.js'
 import TSIG from './rr/tsig.js'
 import TXT from './rr/txt.js'
@@ -66,6 +67,7 @@ export {
   SOA,
   SPF,
   SRV,
+  SVCB,
   TLSA,
   TSIG,
   TXT,
@@ -103,6 +105,7 @@ for (const c of [
   SOA,
   SPF,
   SRV,
+  SVCB,
   TLSA,
   TSIG,
   TXT,

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import DNAME from './rr/dname.js'
 import DNSKEY from './rr/dnskey.js'
 import DS from './rr/ds.js'
 import HINFO from './rr/hinfo.js'
+import HTTPS from './rr/https.js'
 import IPSECKEY from './rr/ipseckey.js'
 import KEY from './rr/key.js'
 import LOC from './rr/loc.js'
@@ -48,6 +49,7 @@ export {
   DNSKEY,
   DS,
   HINFO,
+  HTTPS,
   IPSECKEY,
   KEY,
   LOC,
@@ -86,6 +88,7 @@ for (const c of [
   DNSKEY,
   DS,
   HINFO,
+  HTTPS,
   IPSECKEY,
   KEY,
   LOC,

--- a/rr/https.js
+++ b/rr/https.js
@@ -3,35 +3,35 @@
 
 import RR from '../rr.js'
 
-export default class SVCB extends RR {
+export default class HTTPS extends RR {
   constructor (opts) {
     super(opts)
   }
 
   /****** Resource record specific setters   *******/
   setPriority (val) {
-    this.is16bitInt('SVCB', 'priority', val)
+    this.is16bitInt('HTTPS', 'priority', val)
 
     this.set('priority', val)
   }
 
   setTargetName (val) {
 
-    // this.isFullyQualified('SVCB', 'target name', val)
-    // this.isValidHostname('SVCB', 'target name', val)
+    // this.isFullyQualified('HTTPS', 'target name', val)
+    // this.isValidHostname('HTTPS', 'target name', val)
 
     // RFC 4034: letters in the DNS names are lower cased
     this.set('target name', val.toLowerCase())
   }
 
   setParams (val) {
-    // if (!val) throw new Error(`SVCB: value is required, ${this.citeRFC()}`)
+    // if (!val) throw new Error(`HTTPS: params is required, ${this.citeRFC()}`)
 
     this.set('params', val)
   }
 
   getDescription () {
-    return 'Service Binding'
+    return 'HTTP Semantics'
   }
 
   getRdataFields (arg) {
@@ -43,17 +43,15 @@ export default class SVCB extends RR {
   }
 
   getTypeId () {
-    return 64
+    return 65
   }
 
   /******  IMPORTERS   *******/
 
   fromBind (opts) {
-    // test.example.com  3600  IN  SVCB Priority DomainName FieldValue
-    // _8443._foo.api.example.com. 7200 IN SVCB 0 svc4.example.net.
-    // svc4.example.net.  7200  IN SVCB 3 svc4.example.net. ( alpn="bar" port="8004" )
+    // test.example.com  3600  IN  HTTPS Priority DomainName FieldValue
     const [ owner, ttl, c, type, pri, fqdn ] = opts.bindline.split(/\s+/)
-    return new SVCB({
+    return new HTTPS({
       owner,
       ttl          : parseInt(ttl, 10),
       class        : c,

--- a/rr/https.js
+++ b/rr/https.js
@@ -1,22 +1,18 @@
-
-// import net from 'net'
-
 import RR from '../rr.js'
 
 export default class HTTPS extends RR {
-  constructor (opts) {
+  constructor(opts) {
     super(opts)
   }
 
   /****** Resource record specific setters   *******/
-  setPriority (val) {
+  setPriority(val) {
     this.is16bitInt('HTTPS', 'priority', val)
 
     this.set('priority', val)
   }
 
-  setTargetName (val) {
-
+  setTargetName(val) {
     // this.isFullyQualified('HTTPS', 'target name', val)
     // this.isValidHostname('HTTPS', 'target name', val)
 
@@ -24,41 +20,41 @@ export default class HTTPS extends RR {
     this.set('target name', val.toLowerCase())
   }
 
-  setParams (val) {
+  setParams(val) {
     // if (!val) throw new Error(`HTTPS: params is required, ${this.citeRFC()}`)
 
     this.set('params', val)
   }
 
-  getDescription () {
+  getDescription() {
     return 'HTTP Semantics'
   }
 
-  getRdataFields (arg) {
-    return [ 'priority', 'target name', 'params' ]
+  getRdataFields(arg) {
+    return ['priority', 'target name', 'params']
   }
 
-  getRFCs () {
+  getRFCs() {
     return [9460]
   }
 
-  getTypeId () {
+  getTypeId() {
     return 65
   }
 
   /******  IMPORTERS   *******/
 
-  fromBind (opts) {
-    // test.example.com  3600  IN  HTTPS Priority DomainName FieldValue
-    const [ owner, ttl, c, type, pri, fqdn ] = opts.bindline.split(/\s+/)
+  fromBind(opts) {
+    // test.example.com  3600  IN  HTTPS Priority TargetName Params
+    const [owner, ttl, c, type, pri, fqdn] = opts.bindline.split(/\s+/)
     return new HTTPS({
       owner,
-      ttl          : parseInt(ttl, 10),
-      class        : c,
+      ttl: parseInt(ttl, 10),
+      class: c,
       type,
-      priority     : parseInt(pri, 10),
+      priority: parseInt(pri, 10),
       'target name': fqdn,
-      params        : opts.bindline.split(/\s+/).slice(6).join(' ').trim(),
+      params: opts.bindline.split(/\s+/).slice(6).join(' ').trim(),
     })
   }
 

--- a/rr/svcb.js
+++ b/rr/svcb.js
@@ -1,0 +1,66 @@
+
+// import net from 'net'
+
+import RR from '../rr.js'
+
+export default class SVCB extends RR {
+  constructor (opts) {
+    super(opts)
+  }
+
+  /****** Resource record specific setters   *******/
+  setPriority (val) {
+    this.is16bitInt('SVCB', 'priority', val)
+
+    this.set('priority', val)
+  }
+
+  setDomainName (val) {
+
+    // this.isFullyQualified('SVCB', 'domain name', val)
+    // this.isValidHostname('SVCB', 'domain name', val)
+
+    // RFC 4034: letters in the DNS names are lower cased
+    this.set('domain name', val.toLowerCase())
+  }
+
+  setValue (val) {
+    // if (!val) throw new Error(`SVCB: value is required, ${this.citeRFC()}`)
+
+    this.set('value', val)
+  }
+
+  getDescription () {
+    return 'Service'
+  }
+
+  getRdataFields (arg) {
+    return [ 'priority', 'domain name', 'value' ]
+  }
+
+  getRFCs () {
+    return [ ]
+  }
+
+  getTypeId () {
+    return 64
+  }
+
+  /******  IMPORTERS   *******/
+
+  fromBind (str) {
+    // test.example.com  3600  IN  SVCB Priority DomainName FieldValue
+    const [ owner, ttl, c, type, pri, fqdn ] = str.split(/\s+/)
+    return new SVCB({
+      owner,
+      ttl          : parseInt(ttl, 10),
+      class        : c,
+      type,
+      priority     : parseInt(pri, 10),
+      'domain name': fqdn,
+      value        : str.split(/\s+/).slice(6).join(' ').trim(),
+    })
+  }
+
+  /******  EXPORTERS   *******/
+}

--- a/rr/svcb.js
+++ b/rr/svcb.js
@@ -1,22 +1,18 @@
-
-// import net from 'net'
-
 import RR from '../rr.js'
 
 export default class SVCB extends RR {
-  constructor (opts) {
+  constructor(opts) {
     super(opts)
   }
 
   /****** Resource record specific setters   *******/
-  setPriority (val) {
+  setPriority(val) {
     this.is16bitInt('SVCB', 'priority', val)
 
     this.set('priority', val)
   }
 
-  setTargetName (val) {
-
+  setTargetName(val) {
     // this.isFullyQualified('SVCB', 'target name', val)
     // this.isValidHostname('SVCB', 'target name', val)
 
@@ -24,43 +20,43 @@ export default class SVCB extends RR {
     this.set('target name', val.toLowerCase())
   }
 
-  setParams (val) {
+  setParams(val) {
     // if (!val) throw new Error(`SVCB: value is required, ${this.citeRFC()}`)
 
     this.set('params', val)
   }
 
-  getDescription () {
+  getDescription() {
     return 'Service Binding'
   }
 
-  getRdataFields (arg) {
-    return [ 'priority', 'target name', 'params' ]
+  getRdataFields(arg) {
+    return ['priority', 'target name', 'params']
   }
 
-  getRFCs () {
+  getRFCs() {
     return [9460]
   }
 
-  getTypeId () {
+  getTypeId() {
     return 64
   }
 
   /******  IMPORTERS   *******/
 
-  fromBind (opts) {
-    // test.example.com  3600  IN  SVCB Priority DomainName FieldValue
+  fromBind(opts) {
+    // test.example.com  3600  IN  SVCB Priority TargetName Params
     // _8443._foo.api.example.com. 7200 IN SVCB 0 svc4.example.net.
     // svc4.example.net.  7200  IN SVCB 3 svc4.example.net. ( alpn="bar" port="8004" )
-    const [ owner, ttl, c, type, pri, fqdn ] = opts.bindline.split(/\s+/)
+    const [owner, ttl, c, type, pri, fqdn] = opts.bindline.split(/\s+/)
     return new SVCB({
       owner,
-      ttl          : parseInt(ttl, 10),
-      class        : c,
+      ttl: parseInt(ttl, 10),
+      class: c,
       type,
-      priority     : parseInt(pri, 10),
+      priority: parseInt(pri, 10),
       'target name': fqdn,
-      params        : opts.bindline.split(/\s+/).slice(6).join(' ').trim(),
+      params: opts.bindline.split(/\s+/).slice(6).join(' ').trim(),
     })
   }
 

--- a/rr/tsig.js
+++ b/rr/tsig.js
@@ -13,7 +13,15 @@ export default class TSIG extends RR {
   }
 
   getRdataFields(arg) {
-    return ['algorithm name', 'time signed', 'fudge', 'mac', 'original id', 'error', 'other']
+    return [
+      'algorithm name',
+      'time signed',
+      'fudge',
+      'mac',
+      'original id',
+      'error',
+      'other',
+    ]
   }
 
   getRFCs() {
@@ -34,7 +42,7 @@ export default class TSIG extends RR {
       ttl: parseInt(ttl, 10),
       class: c,
       type: type,
-      'algorithm': algorithm,
+      algorithm: algorithm,
       // 'time signed': opts.bindline,
       // fudge
       // mac

--- a/rr/wks.js
+++ b/rr/wks.js
@@ -28,15 +28,16 @@ export default class WKS extends RR {
 
   fromBind(opts) {
     // test.example.com  3600  IN  WKS 192.168.1.1 TCP 25
-    const [owner, ttl, c, type, address, protocol, bitmap] = opts.bindline.split(/\s+/)
+    const [owner, ttl, c, type, address, protocol, bitmap] =
+      opts.bindline.split(/\s+/)
     return new WKS({
       owner,
       ttl: parseInt(ttl, 10),
       class: c,
       type,
-      address,  // 32-bit int
+      address, // 32-bit int
       protocol, // 8-bit int, 6=TCP, 17=UDP
-      bitmap,   // var len bit map, must be multiple of 8
+      bitmap, // var len bit map, must be multiple of 8
     })
   }
 

--- a/test/https.js
+++ b/test/https.js
@@ -1,0 +1,57 @@
+
+// import assert from 'assert'
+
+import * as base from './base.js'
+
+import HTTPS from '../rr/https.js'
+
+const defaults = { class: 'IN', ttl: 3600, type: 'HTTPS' }
+
+const validRecords = [
+  {
+    ...defaults,
+    owner        : '_8443._foo.api.example.com.',
+    ttl          : 7200,
+    priority     : 0,
+    'target name': 'svc4.example.net.',
+    params       : 'alpn="bar" port="8004" ech="..."',
+    testB        : '_8443._foo.api.example.com.\t7200\tIN\tHTTPS\t0\tsvc4.example.net.\talpn="bar" port="8004" ech="..."\n',
+  },
+  {
+    ...defaults,
+    owner        : '_8080._foo.example.com.',
+    priority     : 0,
+    'target name': 'foosvc.example.net.',
+    params        : '',
+    testB        : '_8080._foo.example.com.\t3600\tIN\tHTTPS\t0\tfoosvc.example.net.\t\n',
+  },
+/*
+  _1234._bar.example.com. 300 IN HTTPS 1 svc1.example.net. ( ech="111..." ipv6hint=2001:db8::1 port=1234 )
+                                 HTTPS 2 svc2.example.net. ( ech="222..." ipv6hint=2001:db8::2 port=1234 )
+*/
+]
+
+const invalidRecords = [
+  // {
+  //   ...defaults,
+  //   owner : 'test.example.com.',
+  //   'target name': 'not-full-qualified.example.com',
+  //   params  : /must be a 16-bit integer/,
+  // },
+]
+
+describe('HTTPS record', function () {
+  base.valid(HTTPS, validRecords)
+  base.invalid(HTTPS, invalidRecords)
+
+  base.getDescription(HTTPS)
+  base.getRFCs(HTTPS, validRecords[0])
+  base.getFields(HTTPS, [ 'priority', 'target name', 'params' ])
+  base.getTypeId(HTTPS, 65)
+
+  base.toBind(HTTPS, validRecords)
+  // base.toTinydns(HTTPS, validRecords)
+
+  base.fromBind(HTTPS, validRecords)
+  // base.fromTinydns(HTTPS, validRecords)
+})

--- a/test/https.js
+++ b/test/https.js
@@ -1,6 +1,3 @@
-
-// import assert from 'assert'
-
 import * as base from './base.js'
 
 import HTTPS from '../rr/https.js'
@@ -10,22 +7,24 @@ const defaults = { class: 'IN', ttl: 3600, type: 'HTTPS' }
 const validRecords = [
   {
     ...defaults,
-    owner        : '_8443._foo.api.example.com.',
-    ttl          : 7200,
-    priority     : 0,
+    owner: '_8443._foo.api.example.com.',
+    ttl: 7200,
+    priority: 0,
     'target name': 'svc4.example.net.',
-    params       : 'alpn="bar" port="8004" ech="..."',
-    testB        : '_8443._foo.api.example.com.\t7200\tIN\tHTTPS\t0\tsvc4.example.net.\talpn="bar" port="8004" ech="..."\n',
+    params: 'alpn="bar" port="8004" ech="..."',
+    testB:
+      '_8443._foo.api.example.com.\t7200\tIN\tHTTPS\t0\tsvc4.example.net.\talpn="bar" port="8004" ech="..."\n',
   },
   {
     ...defaults,
-    owner        : '_8080._foo.example.com.',
-    priority     : 0,
+    owner: '_8080._foo.example.com.',
+    priority: 0,
     'target name': 'foosvc.example.net.',
-    params        : '',
-    testB        : '_8080._foo.example.com.\t3600\tIN\tHTTPS\t0\tfoosvc.example.net.\t\n',
+    params: '',
+    testB:
+      '_8080._foo.example.com.\t3600\tIN\tHTTPS\t0\tfoosvc.example.net.\t\n',
   },
-/*
+  /*
   _1234._bar.example.com. 300 IN HTTPS 1 svc1.example.net. ( ech="111..." ipv6hint=2001:db8::1 port=1234 )
                                  HTTPS 2 svc2.example.net. ( ech="222..." ipv6hint=2001:db8::2 port=1234 )
 */
@@ -46,7 +45,7 @@ describe('HTTPS record', function () {
 
   base.getDescription(HTTPS)
   base.getRFCs(HTTPS, validRecords[0])
-  base.getFields(HTTPS, [ 'priority', 'target name', 'params' ])
+  base.getFields(HTTPS, ['priority', 'target name', 'params'])
   base.getTypeId(HTTPS, 65)
 
   base.toBind(HTTPS, validRecords)

--- a/test/svcb.js
+++ b/test/svcb.js
@@ -13,16 +13,16 @@ const validRecords = [
     owner        : '_8443._foo.api.example.com.',
     ttl          : 7200,
     priority     : 0,
-    'domain name': 'svc4.example.net.',
-    'value'      : 'alpn="bar" port="8004" ech="..."',
+    'target name': 'svc4.example.net.',
+    params       : 'alpn="bar" port="8004" ech="..."',
     testB        : '_8443._foo.api.example.com.\t7200\tIN\tSVCB\t0\tsvc4.example.net.\talpn="bar" port="8004" ech="..."\n',
   },
   {
     ...defaults,
     owner        : '_8080._foo.example.com.',
     priority     : 0,
-    'domain name': 'foosvc.example.net.',
-    value        : '',
+    'target name': 'foosvc.example.net.',
+    params        : '',
     testB        : '_8080._foo.example.com.\t3600\tIN\tSVCB\t0\tfoosvc.example.net.\t\n',
   },
 /*
@@ -35,8 +35,8 @@ const invalidRecords = [
   // {
   //   ...defaults,
   //   owner : 'test.example.com.',
-  //   'domain name': 'not-full-qualified.example.com',
-  //   value  : /must be a 16-bit integer/,
+  //   'target name': 'not-full-qualified.example.com',
+  //   params  : /must be a 16-bit integer/,
   // },
 ]
 
@@ -45,8 +45,8 @@ describe('SVCB record', function () {
   base.invalid(SVCB, invalidRecords)
 
   base.getDescription(SVCB)
-  // base.getRFCs(SVCB, validRecords[0])
-  base.getFields(SVCB, [ 'priority', 'domain name', 'value' ])
+  base.getRFCs(SVCB, validRecords[0])
+  base.getFields(SVCB, [ 'priority', 'target name', 'params' ])
   base.getTypeId(SVCB, 64)
 
   base.toBind(SVCB, validRecords)

--- a/test/svcb.js
+++ b/test/svcb.js
@@ -1,0 +1,57 @@
+
+// import assert from 'assert'
+
+import * as base from './base.js'
+
+import SVCB from '../rr/svcb.js'
+
+const defaults = { class: 'IN', ttl: 3600, type: 'SVCB' }
+
+const validRecords = [
+  {
+    ...defaults,
+    owner        : '_8443._foo.api.example.com.',
+    ttl          : 7200,
+    priority     : 0,
+    'domain name': 'svc4.example.net.',
+    'value'      : 'alpn="bar" port="8004" ech="..."',
+    testB        : '_8443._foo.api.example.com.\t7200\tIN\tSVCB\t0\tsvc4.example.net.\talpn="bar" port="8004" ech="..."\n',
+  },
+  {
+    ...defaults,
+    owner        : '_8080._foo.example.com.',
+    priority     : 0,
+    'domain name': 'foosvc.example.net.',
+    value        : '',
+    testB        : '_8080._foo.example.com.\t3600\tIN\tSVCB\t0\tfoosvc.example.net.\t\n',
+  },
+/*
+  _1234._bar.example.com. 300 IN SVCB 1 svc1.example.net. ( ech="111..." ipv6hint=2001:db8::1 port=1234 )
+                                 SVCB 2 svc2.example.net. ( ech="222..." ipv6hint=2001:db8::2 port=1234 )
+*/
+]
+
+const invalidRecords = [
+  // {
+  //   ...defaults,
+  //   owner : 'test.example.com.',
+  //   'domain name': 'not-full-qualified.example.com',
+  //   value  : /must be a 16-bit integer/,
+  // },
+]
+
+describe('SVCB record', function () {
+  base.valid(SVCB, validRecords)
+  base.invalid(SVCB, invalidRecords)
+
+  base.getDescription(SVCB)
+  // base.getRFCs(SVCB, validRecords[0])
+  base.getFields(SVCB, [ 'priority', 'domain name', 'value' ])
+  base.getTypeId(SVCB, 64)
+
+  base.toBind(SVCB, validRecords)
+  // base.toTinydns(SVCB, validRecords)
+
+  base.fromBind(SVCB, validRecords)
+  // base.fromTinydns(SVCB, validRecords)
+})

--- a/test/svcb.js
+++ b/test/svcb.js
@@ -1,6 +1,3 @@
-
-// import assert from 'assert'
-
 import * as base from './base.js'
 
 import SVCB from '../rr/svcb.js'
@@ -10,22 +7,24 @@ const defaults = { class: 'IN', ttl: 3600, type: 'SVCB' }
 const validRecords = [
   {
     ...defaults,
-    owner        : '_8443._foo.api.example.com.',
-    ttl          : 7200,
-    priority     : 0,
+    owner: '_8443._foo.api.example.com.',
+    ttl: 7200,
+    priority: 0,
     'target name': 'svc4.example.net.',
-    params       : 'alpn="bar" port="8004" ech="..."',
-    testB        : '_8443._foo.api.example.com.\t7200\tIN\tSVCB\t0\tsvc4.example.net.\talpn="bar" port="8004" ech="..."\n',
+    params: 'alpn="bar" port="8004" ech="..."',
+    testB:
+      '_8443._foo.api.example.com.\t7200\tIN\tSVCB\t0\tsvc4.example.net.\talpn="bar" port="8004" ech="..."\n',
   },
   {
     ...defaults,
-    owner        : '_8080._foo.example.com.',
-    priority     : 0,
+    owner: '_8080._foo.example.com.',
+    priority: 0,
     'target name': 'foosvc.example.net.',
-    params        : '',
-    testB        : '_8080._foo.example.com.\t3600\tIN\tSVCB\t0\tfoosvc.example.net.\t\n',
+    params: '',
+    testB:
+      '_8080._foo.example.com.\t3600\tIN\tSVCB\t0\tfoosvc.example.net.\t\n',
   },
-/*
+  /*
   _1234._bar.example.com. 300 IN SVCB 1 svc1.example.net. ( ech="111..." ipv6hint=2001:db8::1 port=1234 )
                                  SVCB 2 svc2.example.net. ( ech="222..." ipv6hint=2001:db8::2 port=1234 )
 */
@@ -46,7 +45,7 @@ describe('SVCB record', function () {
 
   base.getDescription(SVCB)
   base.getRFCs(SVCB, validRecords[0])
-  base.getFields(SVCB, [ 'priority', 'target name', 'params' ])
+  base.getFields(SVCB, ['priority', 'target name', 'params'])
   base.getTypeId(SVCB, 64)
 
   base.toBind(SVCB, validRecords)


### PR DESCRIPTION
- [x] wait for RFC / acceptance?
- [x] add HTTPS (65) support

### references
- [RFC 9460](https://datatracker.ietf.org/doc/rfc9460/)
- IETF: [Service binding and parameter specification via the DNS (DNS SVCB and HTTPSSVC)](https://www.ietf.org/archive/id/draft-ietf-dnsop-svcb-httpssvc-03.html)
- github: [dns-alt-svc](https://github.com/MikeBishop/dns-alt-svc)
