### PR TITLE
release 1.1.0

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,7 +31,7 @@ jobs:
 
       - run: npm run test
 
-      - run: npm publish --access public
+      - run: npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 #### 1.1.0 - 2022-04-22
 
 - feat(tinydns): add ipv4toOctal, octalToIPv4, base64toOctal, octalToBase64
-- feat(DS,IPSECKEY,TLSA): added to/fromTinydns support
+- feat(DNSKEY,DS,IPSECKEY,TLSA): added to/fromTinydns support
 - feat(NAPTR): finished fromTinydns
 - feat(bindline & tinyline): pass in opts (was only line), so defaults (serial, ttl, etc) can be passed in.
 - fix(SSHFP): algo & fptype are 1 byte, not 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
 #### 1.1.0 - 2022-04-22
 
 - feat(tinydns): add ipv4toOctal, octalToIPv4, base64toOctal, octalToBase64
-- feat(IPSECKEY): added tinydns import/export
+- feat(DS,IPSECKEY,TLSA): added to/fromTinydns support
+- feat(NAPTR): finished fromTinydns
 - feat(bindline & tinyline): pass in opts (was only line), so defaults (serial, ttl, etc) can be passed in.
 - fix(SSHFP): algo & fptype are 1 byte, not 2
 - fix:(cname): fully qualify the target
 - test: add tinydns.unpackDomainName, ipv4toOctal, octalToIPv4
 - test(SRV): add another test case (found a bug in NicTool 2)
+- test(IPSECKEY): expand test coverage
 - tinydns.unpackdomain: return fqdn + length, for RRs where the FQDN is part of the byte stream
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 
 #### 1.N.N - YYYY-MM-DD
 
+
+#### 1.1.0 - 2022-04-22
+
+- feat(tinydns): add ipv4toOctal, octalToIPv4, base64toOctal, octalToBase64
+- feat(IPSECKEY): added tinydns import/export
+- feat(bindline & tinyline): pass in opts (was only line), so defaults (serial, ttl, etc) can be passed in.
+- fix(SSHFP): algo & fptype are 1 byte, not 2
+- fix:(cname): fully qualify the target
+- test: add tinydns.unpackDomainName, ipv4toOctal, octalToIPv4
+- test(SRV): add another test case (found a bug in NicTool 2)
+- tinydns.unpackdomain: return fqdn + length, for RRs where the FQDN is part of the byte stream
+
+
 #### 1.0.1 - 2022-04-19
 
 - feat(IPSECKEY): added basic support

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ PRs are welcome, especially PRs with tests.
 | **CERT**   |                  |                  |                  |                  |
 | **CNAME**  |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **DNAME**  |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-| **DNSKEY** |:white_check_mark:|                  |:white_check_mark:|                  |
+| **DNSKEY** |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **DS**     |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **HINFO**  |:white_check_mark:|                  |:white_check_mark:|                  |
 |**IPSECKEY**|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ PRs are welcome, especially PRs with tests.
 | **DNSKEY** |:white_check_mark:|                  |:white_check_mark:|                  |
 | **DS**     |:white_check_mark:|                  |:white_check_mark:|                  |
 | **HINFO**  |:white_check_mark:|                  |:white_check_mark:|                  |
-|**IPSECKEY**|:white_check_mark:|                  |:white_check_mark:|                  |
+|**IPSECKEY**|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **KEY**    |                  |                  |                  |                  |
 | **LOC**    |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **MX**     |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ PRs are welcome, especially PRs with tests.
 | **KEY**    |                  |                  |                  |                  |
 | **LOC**    |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **MX**     |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-| **NAPTR**  |:white_check_mark:|:white_check_mark:|:white_check_mark:|                  |
+| **NAPTR**  |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **NS**     |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **NSEC**   |                  |                  |                  |                  |
 | **NSEC3**  |                  |                  |                  |                  |

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ PRs are welcome, especially PRs with tests.
 | **SPF**    |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **SRV**    |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **SSHFP**  |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-| **TLSA**   |:white_check_mark:|                  |:white_check_mark:|                  |
+| **TLSA**   |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **TXT**    |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **URI**    |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ PRs are welcome, especially PRs with tests.
 | **CNAME**  |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **DNAME**  |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **DNSKEY** |:white_check_mark:|                  |:white_check_mark:|                  |
-| **DS**     |:white_check_mark:|                  |:white_check_mark:|                  |
+| **DS**     |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **HINFO**  |:white_check_mark:|                  |:white_check_mark:|                  |
 |**IPSECKEY**|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | **KEY**    |                  |                  |                  |                  |

--- a/lib/tinydns.js
+++ b/lib/tinydns.js
@@ -90,13 +90,15 @@ export function unpackDomainName (fqdn) {
   const labels = []
   let pos = 0
   let len
-  while ((len = fqdn.readUInt8(pos))) {
+  while ((len = fqdn.readUInt8(pos))) {  // encoded length byte
     pos++
     labels.push(fqdn.slice(pos, pos + len).toString())
     pos = +(pos + len)
   }
-
-  return labels.join('.')
+  const r = `${labels.join('.')}.`
+  // char position + length of last label + label length chars + null byte
+  const strLen = pos + len + labels.length * 4 + 1
+  return [ r, strLen ]
 }
 
 export function packHex (str) {

--- a/lib/tinydns.js
+++ b/lib/tinydns.js
@@ -138,3 +138,25 @@ export function UInt32toOctal (n) {
   }
   return r
 }
+
+export function ipv4toOctal (ip) {
+  return UInt32toOctal(ip.split`.`.reduce((int, value) => int * 256 + +value))
+}
+
+export function octalToIPv4 (str) {
+  const asInt = octalToUInt32(str)
+  return [ 24,16,8,0 ].map(n => (asInt >> n) & 0xff).join('.')
+}
+
+export function base64toOctal (str) {
+  const bytes = Buffer.from(str, 'base64')
+  let escaped = ''
+  for (const b of bytes) {
+    escaped += /[A-Za-z0-9\-.]/.test(String.fromCharCode(b)) ? String.fromCharCode(b) : UInt8toOctal(b)
+  }
+  return escaped
+}
+
+export function octalToBase64 (str) {
+  return Buffer.from(octalToChar(str), 'binary').toString('base64')
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dns-resource-record",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "DNS Resource Records",
   "main": "index.js",
   "type": "module",

--- a/rr.js
+++ b/rr.js
@@ -7,8 +7,8 @@ export default class RR extends Map {
 
     if (opts.default) this.default = opts.default
 
-    if (opts.bindline) return this.fromBind(opts.bindline)
-    if (opts.tinyline) return this.fromTinydns(opts.tinyline)
+    if (opts.bindline) return this.fromBind(opts)
+    if (opts.tinyline) return this.fromTinydns(opts)
 
     // tinydns specific
     this.setLocation(opts?.location)

--- a/rr/a.js
+++ b/rr/a.js
@@ -32,9 +32,9 @@ export default class A extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // +fqdn:ip:ttl:timestamp:lo
-    const [ owner, ip, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ owner, ip, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
 
     return new A({
       owner    : this.fullyQualify(owner),
@@ -46,9 +46,9 @@ export default class A extends RR {
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  A  192.0.2.127
-    const [ owner, ttl, c, type, address ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, address ] = opts.bindline.split(/\s+/)
     return new A({
       owner,
       ttl  : parseInt(ttl, 10),

--- a/rr/aaaa.js
+++ b/rr/aaaa.js
@@ -38,7 +38,8 @@ export default class AAAA extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
+    const str = opts.tinyline
     let fqdn, ip, n, rdata, ttl, ts, loc
 
     switch (str[0]) {
@@ -67,9 +68,9 @@ export default class AAAA extends RR {
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  AAAA  ...
-    const [ owner, ttl, c, type, ip ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, ip ] = opts.bindline.split(/\s+/)
     return new AAAA({
       owner,
       ttl    : parseInt(ttl, 10),

--- a/rr/caa.js
+++ b/rr/caa.js
@@ -72,9 +72,9 @@ export default class CAA extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // CAA via generic, :fqdn:n:rdata:ttl:timestamp:lo
-    const [ fqdn, n, rdata, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, n, rdata, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
     if (n != 257) throw new Error('CAA fromTinydns, invalid n')
 
     const flags  = TINYDNS.octalToUInt8(rdata.substring(0, 4))
@@ -96,10 +96,10 @@ export default class CAA extends RR {
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  CAA flags, tags, value
-    const fields = str.match(/^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+([0-9]+)\s+(\w+)\s+("[^"]+"|[^\s]+?)\s*$/i)
-    if (!fields) throw new Error(`unable to parse: ${str}`)
+    const fields = opts.bindline.match(/^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+([0-9]+)\s+(\w+)\s+("[^"]+"|[^\s]+?)\s*$/i)
+    if (!fields) throw new Error(`unable to parse: ${opts.bindline}`)
 
     const [ owner, ttl, c, type, flags, tag, value ] = fields.slice(1)
     return new CAA({

--- a/rr/cert.js
+++ b/rr/cert.js
@@ -56,9 +56,9 @@ export default class CERT extends RR {
 
   /******  IMPORTERS   *******/
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  CERT  certtype, keytag, algo, cert
-    const [ owner, ttl, c, type, certtype, keytag, algo, certificate  ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, certtype, keytag, algo, certificate  ] = opts.bindline.split(/\s+/)
     return new CERT({
       owner,
       ttl        : parseInt(ttl, 10),

--- a/rr/cname.js
+++ b/rr/cname.js
@@ -42,23 +42,23 @@ export default class CNAME extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // Cfqdn:p:ttl:timestamp:lo
-    const [ fqdn, p, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, p, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
 
     return new CNAME({
       owner    : this.fullyQualify(fqdn),
       ttl      : parseInt(ttl, 10),
       type     : 'CNAME',
-      cname    : p,
+      cname    : this.fullyQualify(p),
       timestamp: ts,
       location : loc !== '' && loc !== '\n' ? loc : '',
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  CNAME  ...
-    const [ owner, ttl, c, type, cname ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, cname ] = opts.bindline.split(/\s+/)
     return new CNAME({
       owner,
       ttl  : parseInt(ttl, 10),

--- a/rr/dname.js
+++ b/rr/dname.js
@@ -47,7 +47,7 @@ export default class DNAME extends RR {
     return new DNAME({
       type     : 'DNAME',
       owner    : this.fullyQualify(fqdn),
-      target   : `${TINYDNS.unpackDomainName(rdata)}.`,
+      target   : (TINYDNS.unpackDomainName(rdata))[0],
       ttl      : parseInt(ttl, 10),
       timestamp: ts,
       location : loc !== '' && loc !== '\n' ? loc : '',

--- a/rr/dname.js
+++ b/rr/dname.js
@@ -39,9 +39,9 @@ export default class DNAME extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // DNAME via generic, :fqdn:n:rdata:ttl:timestamp:lo
-    const [ fqdn, n, rdata, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, n, rdata, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
     if (n != 39) throw new Error('DNAME fromTinydns, invalid n')
 
     return new DNAME({
@@ -54,9 +54,9 @@ export default class DNAME extends RR {
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  DNAME  ...
-    const [ owner, ttl, c, type, target ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, target ] = opts.bindline.split(/\s+/)
     return new DNAME({
       owner,
       ttl  : parseInt(ttl, 10),

--- a/rr/dnskey.js
+++ b/rr/dnskey.js
@@ -56,10 +56,10 @@ export default class DNSKEY extends RR {
 
   /******  IMPORTERS   *******/
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  DNSKEY Flags Protocol Algorithm PublicKey
-    const match = str.match(/^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+\s*(.*?)\s*$/)
-    if (!match) throw new Error(`unable to parse DNSKEY: ${str}`)
+    const match = opts.bindline.match(/^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+\s*(.*?)\s*$/)
+    if (!match) throw new Error(`unable to parse DNSKEY: ${opts.bindline}`)
     const [ owner, ttl, c, type, flags, protocol, algorithm, publickey ] = match.slice(1)
 
     return new DNSKEY({

--- a/rr/ds.js
+++ b/rr/ds.js
@@ -53,9 +53,9 @@ export default class DS extends RR {
 
   /******  IMPORTERS   *******/
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  DS Key Tag Algorithm, Digest Type, Digest
-    const [ owner, ttl, c, type, keytag, algorithm, digesttype ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, keytag, algorithm, digesttype ] = opts.bindline.split(/\s+/)
     return new DS({
       owner,
       ttl          : parseInt(ttl, 10),
@@ -64,7 +64,7 @@ export default class DS extends RR {
       'key tag'    : parseInt(keytag,     10),
       algorithm    : parseInt(algorithm,  10),
       'digest type': parseInt(digesttype, 10),
-      digest       : str.split(/\s+/).slice(7).join(' ').trim(),
+      digest       : opts.bindline.split(/\s+/).slice(7).join(' ').trim(),
     })
   }
 

--- a/rr/hinfo.js
+++ b/rr/hinfo.js
@@ -38,10 +38,10 @@ export default class HINFO extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  HINFO   DEC-2060 TOPS20
-    const match = str.match(/([^\s]+)\s+([0-9]+)\s+(IN)\s+(HINFO)\s+("[^"]+"|[^\s]+)\s+("[^"]+"|[^\s]+)/i)
-    if (!match) throw new Error(`unable to parse HINFO: ${str}`)
+    const match = opts.bindline.match(/([^\s]+)\s+([0-9]+)\s+(IN)\s+(HINFO)\s+("[^"]+"|[^\s]+)\s+("[^"]+"|[^\s]+)/i)
+    if (!match) throw new Error(`unable to parse HINFO: ${opts.bindline}`)
     const [ owner, ttl, c, type, cpu, os ] = match.slice(1)
 
     return new HINFO({
@@ -54,7 +54,7 @@ export default class HINFO extends RR {
     })
   }
 
-  // fromTinydns (str) {
+  // fromTinydns (opts) {
   //   // HINFO via generic, :fqdn:n:rdata:ttl:timestamp:lo
   // }
 

--- a/rr/ipseckey.js
+++ b/rr/ipseckey.js
@@ -1,5 +1,9 @@
 
+import net from 'net'
+
 import RR from '../rr.js'
+
+import * as TINYDNS from '../lib/tinydns.js'
 
 export default class IPSECKEY extends RR {
   constructor (opts) {
@@ -31,14 +35,24 @@ export default class IPSECKEY extends RR {
   }
 
   setGateway (val) {
-    if (this.get('gateway') === 0 && val !== '.')
-      throw new Error(`IPSECKEY: gateway invalid, ${this.citeRFC()}`)
+    const gwErr = new Error(`IPSECKEY: gateway invalid, ${this.citeRFC()}`)
+    switch (this.get('gateway type')) {
+      case 0:
+        if (val !== '.') throw gwErr
+        break
+      case 1:
+        if (!net.isIPv4(val)) throw gwErr
+        break
+      case 2:
+        if (!net.isIPv6(val)) throw gwErr
+        break
+    }
 
     this.set('gateway', val)
   }
 
   setPublickey (val) {
-    if (!val) throw new Error(`IPSECKEY: publickey is required, ${this.citeRFC()}`)
+    // if (val) throw new Error(`IPSECKEY: publickey is optional, ${this.citeRFC()}`)
 
     this.set('publickey', val)
   }
@@ -60,10 +74,9 @@ export default class IPSECKEY extends RR {
   }
 
   /******  IMPORTERS   *******/
-
-  fromBind (str) {
+  fromBind (opts) {
     // FQDN TTL CLASS IPSECKEY Precedence GatewayType Algorithm Gateway PublicKey
-    const [ owner, ttl, c, type, prec, gwt, algo, gateway, publickey ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, prec, gwt, algo, gateway, publickey ] = opts.bindline.split(/\s+/)
     return new IPSECKEY({
       owner,
       ttl           : parseInt(ttl, 10),
@@ -77,5 +90,79 @@ export default class IPSECKEY extends RR {
     })
   }
 
+  fromTinydns (opts) {
+    const [ fqdn, n, rdata, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
+    if (n != 45) throw new Error('IPSECKEY fromTinydns, invalid n')
+
+    const precedence = TINYDNS.octalToUInt8(rdata.substring(0, 4))
+    const gwType     = TINYDNS.octalToUInt8(rdata.substring(4, 8))
+    const algorithm  = TINYDNS.octalToUInt8(rdata.substring(8, 12))
+
+    const pos = 12
+    let len, gateway, octalPK
+
+    switch (gwType) {
+      case 0:     // no gateway
+        len = 0
+        octalPK = rdata.substring(pos)
+        break
+      case 1:     // 4-byte IPv4 address
+        len = 16
+        gateway = TINYDNS.octalToIPv4(rdata.substring(pos, len))
+        octalPK = rdata.substring(pos + len)
+        break
+      case 2:     // 16-byte IPv6
+        len = 64
+        gateway = TINYDNS.octalToHex(rdata.substring(pos, len))
+        octalPK = rdata.substring(pos + len)
+        break
+      case 3:     // wire encoded domain name
+        [ gateway, len ] = TINYDNS.unpackDomainName(rdata.substring(pos))
+        octalPK = rdata.substring(pos + len)
+        break
+    }
+
+    return new IPSECKEY({
+      owner         : this.fullyQualify(fqdn),
+      ttl           : parseInt(ttl, 10),
+      type          : 'IPSECKEY',
+      precedence,
+      'gateway type': gwType,
+      algorithm,
+      gateway,
+      publickey     : TINYDNS.octalToBase64(octalPK),
+      timestamp     : ts,
+      location      : loc !== '' && loc !== '\n' ? loc : '',
+    })
+  }
+
   /******  EXPORTERS   *******/
+
+  toTinydns () {
+    const rdataRe = new RegExp(/[\r\n\t:\\/]/, 'g')
+
+    let rdata = ''
+    rdata += TINYDNS.UInt8toOctal(this.get('precedence'))
+    rdata += TINYDNS.UInt8toOctal(this.get('gateway type'))
+    rdata += TINYDNS.UInt8toOctal(this.get('algorithm'))
+
+    switch (this.get('gateway type')) {
+      case 0:
+        rdata += TINYDNS.escapeOctal(rdataRe, '.')
+        break
+      case 1:
+        rdata += TINYDNS.ipv4asOctal(this.get('gateway'))
+        break
+      case 2:
+        rdata += TINYDNS.ipv4asOctal(this.get('gateway'))
+        break
+      case 3:
+        rdata += TINYDNS.packDomainName(this.get('gateway'))
+        break
+    }
+
+    rdata += TINYDNS.base64toOctal(this.get('publickey'))
+
+    return this.getTinydnsGeneric(rdata)
+  }
 }

--- a/rr/key.js
+++ b/rr/key.js
@@ -54,9 +54,9 @@ export default class KEY extends RR {
 
   /******  IMPORTERS   *******/
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  KEY Flags Protocol Algorithm PublicKey
-    const [ owner, ttl, c, type, flags, protocol, algorithm ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, flags, protocol, algorithm ] = opts.bindline.split(/\s+/)
     return new KEY({
       owner,
       ttl      : parseInt(ttl, 10),
@@ -65,7 +65,7 @@ export default class KEY extends RR {
       flags    : parseInt(flags,     10),
       protocol : parseInt(protocol, 10),
       algorithm: parseInt(algorithm,  10),
-      publickey: str.split(/\s+/).slice(7).join(' ').trim(),
+      publickey: opts.bindline.split(/\s+/).slice(7).join(' ').trim(),
     })
   }
 

--- a/rr/loc.js
+++ b/rr/loc.js
@@ -86,9 +86,9 @@ export default class LOC extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // LOC via generic, :fqdn:n:rdata:ttl:timestamp:lo
-    const [ fqdn, n, rdata, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, n, rdata, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
     if (n != 29) throw new Error('LOC fromTinydns, invalid n')
 
     // divide by 100 is to convert cm to meters
@@ -114,15 +114,15 @@ export default class LOC extends RR {
     })
   }
 
-  fromBind (str) {
-    const [ owner, ttl, c, type ] = str.split(/\s+/)
+  fromBind (opts) {
+    const [ owner, ttl, c, type ] = opts.bindline.split(/\s+/)
 
     return new LOC({
       owner,
       ttl    : parseInt(ttl, 10),
       class  : c,
       type   : type,
-      address: str.split(/\s+/).slice(4).join(' ').trim(),
+      address: opts.bindline.split(/\s+/).slice(4).join(' ').trim(),
     })
   }
 

--- a/rr/mx.js
+++ b/rr/mx.js
@@ -45,10 +45,10 @@ export default class MX extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // @fqdn:ip:x:dist:ttl:timestamp:lo
     // eslint-disable-next-line no-unused-vars
-    const [ owner, ip, x, preference, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ owner, ip, x, preference, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
 
     return new MX({
       type      : 'MX',
@@ -61,9 +61,9 @@ export default class MX extends RR {
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  MX  preference exchange
-    const [ owner, ttl, c, type, preference, exchange ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, preference, exchange ] = opts.bindline.split(/\s+/)
 
     return new MX({
       owner,

--- a/rr/naptr.js
+++ b/rr/naptr.js
@@ -65,37 +65,33 @@ export default class NAPTR extends RR {
     const [ fqdn, n, rdata, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
     if (n != 35) throw new Error('NAPTR fromTinydns, invalid n')
 
+    const binRdata = Buffer.from(TINYDNS.octalToChar(rdata), 'binary')
+
     const rec = {
       type      : 'NAPTR',
       owner     : this.fullyQualify(fqdn),
       ttl       : parseInt(ttl, 10),
       timestamp : ts,
       location  : loc !== '' && loc !== '\n' ? loc : '',
-      order     : TINYDNS.octalToUInt16(rdata.substr(0, 8)),
-      preference: TINYDNS.octalToUInt16(rdata.substr(8, 8)),
+      order     : binRdata.readUInt16BE(0,2),
+      preference: binRdata.readUInt16BE(2,4),
     }
-    /*
-    TODO: incomplete, need to replace octal escapes in regexp with hex escapes
-    'cid.urn.arpa\t86400\tIN\tNAPTR\t100\t10\t""\t""\t"!^urn:cid:.+@([^\\.]+\\.)(.*)$!\x02!i"\t.\n',
-    ':cid.urn.arpa:35:
-    \000\144\000\012\000\000\040!^urn\072cid\072.+@([^\134.]+\134.)(.*)$!\x02!i\001.``000:86400::'
-    */
 
-    let idx = 16
-    const flagsLength = TINYDNS.octalToUInt8(rdata.substr(idx, 4))
-    rec.flags = rdata.substr(idx+4, flagsLength)
-    idx += 4 + flagsLength
+    let idx = 4
+    const flagsLength = binRdata.readUInt8(idx); idx++
+    rec.flags         = binRdata.slice(idx, flagsLength).toString()
+    idx += flagsLength
 
-    const serviceLen = TINYDNS.octalToUInt8(rdata.substr(idx, 4))
-    rec.service = TINYDNS.octalToChar(rdata.substr(idx+4, serviceLen))
-    idx += 4 + serviceLen
+    const serviceLen  = binRdata.readUInt8(idx); idx++
+    rec.service       = binRdata.slice(idx, idx+serviceLen).toString()
+    idx += serviceLen
 
-    const regexpLen = TINYDNS.octalToUInt8(rdata.substr(idx, 4))
-    rec.regexp = TINYDNS.octalToChar(rdata.substr(idx+4, regexpLen))
-    idx += 4 + regexpLen
+    const regexpLen   = binRdata.readUInt8(idx); idx++
+    rec.regexp        = binRdata.slice(idx, idx+regexpLen).toString()
+    idx += regexpLen
 
-    const replaceLen = TINYDNS.octalToUInt8(rdata.substr(idx, 4))
-    rec.replacement = TINYDNS.octalToChar(rdata.substr(idx+4, replaceLen))
+    const replaceLen  = binRdata.readUInt8(idx); idx++
+    rec.replacement   = binRdata.slice(idx, idx+replaceLen).toString()
 
     return new NAPTR(rec)
   }
@@ -125,24 +121,25 @@ export default class NAPTR extends RR {
   /******  EXPORTERS   *******/
   toTinydns () {
 
-    let rdata = ''
-    rdata += TINYDNS.UInt16toOctal(this.get('order'))
-    rdata += TINYDNS.UInt16toOctal(this.get('preference'))
+    let rdata =
+      TINYDNS.UInt16toOctal(this.get('order')) +
+      TINYDNS.UInt16toOctal(this.get('preference')) +
 
-    rdata += TINYDNS.UInt8toOctal(this.get('flags').length)
-    rdata += this.get('flags')
+      TINYDNS.UInt8toOctal(this.get('flags').length) +
+      this.get('flags') +
 
-    rdata += TINYDNS.UInt8toOctal(this.get('service').length)
-    rdata += TINYDNS.escapeOctal(rdataRe, this.get('service'))
+      TINYDNS.UInt8toOctal(this.get('service').length) +
+      TINYDNS.escapeOctal(rdataRe, this.get('service')) +
 
-    rdata += TINYDNS.UInt8toOctal(this.get('regexp').length)
-    rdata += TINYDNS.escapeOctal(rdataRe, this.get('regexp'))
+      TINYDNS.UInt8toOctal(this.get('regexp').length) +
+      TINYDNS.escapeOctal(rdataRe, this.get('regexp'))
 
-    if (this.set('replacement' !== '')) {
-      rdata += TINYDNS.UInt8toOctal(this.get('replacement').length)
-      rdata += TINYDNS.escapeOctal(rdataRe, this.get('replacement'))
+    const replacement = this.get('replacement')
+    if (replacement !== '') {
+      rdata += TINYDNS.UInt8toOctal(replacement.length)
+      rdata += TINYDNS.escapeOctal(rdataRe, replacement)
     }
-    rdata += '``000'
+    rdata += '\\000'
 
     return this.getTinydnsGeneric(rdata)
   }

--- a/rr/naptr.js
+++ b/rr/naptr.js
@@ -60,9 +60,9 @@ export default class NAPTR extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // NAPTR via generic, :fqdn:n:rdata:ttl:timestamp:lo
-    const [ fqdn, n, rdata, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, n, rdata, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
     if (n != 35) throw new Error('NAPTR fromTinydns, invalid n')
 
     const rec = {
@@ -75,7 +75,7 @@ export default class NAPTR extends RR {
       preference: TINYDNS.octalToUInt16(rdata.substr(8, 8)),
     }
     /*
-    TODO: incomplete, need to remove octal escapes from regexp
+    TODO: incomplete, need to replace octal escapes in regexp with hex escapes
     'cid.urn.arpa\t86400\tIN\tNAPTR\t100\t10\t""\t""\t"!^urn:cid:.+@([^\\.]+\\.)(.*)$!\x02!i"\t.\n',
     ':cid.urn.arpa:35:
     \000\144\000\012\000\000\040!^urn\072cid\072.+@([^\134.]+\134.)(.*)$!\x02!i\001.``000:86400::'
@@ -100,7 +100,8 @@ export default class NAPTR extends RR {
     return new NAPTR(rec)
   }
 
-  fromBind (str) {
+  fromBind (opts) {
+    const str = opts.bindline
     // test.example.com  3600  IN  NAPTR order, preference, "flags", "service", "regexp", replacement
     const [ owner, ttl, c, type, order, preference ] = str.split(/\s+/)
     const [ flags, service, regexp ] = str.match(/(?:").*?(?:"\s)/g)

--- a/rr/ns.js
+++ b/rr/ns.js
@@ -35,10 +35,10 @@ export default class NS extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // &fqdn:ip:x:ttl:timestamp:lo
     // eslint-disable-next-line no-unused-vars
-    const [ fqdn, ip, dname, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, ip, dname, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
 
     return new NS({
       type     : 'NS',
@@ -50,9 +50,9 @@ export default class NS extends RR {
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  NS dname
-    const [ owner, ttl, c, type, dname ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, dname ] = opts.bindline.split(/\s+/)
 
     return new NS({
       owner,

--- a/rr/nsec.js
+++ b/rr/nsec.js
@@ -41,29 +41,21 @@ export default class NSEC extends RR {
   }
 
   /******  IMPORTERS   *******/
-  // fromTinydns (str) {
-  // }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  NSEC NextDomain TypeBitMaps
-    const [ owner, ttl, c, type, next ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, next ] = opts.bindline.split(/\s+/)
     return new NSEC({
       owner,
       ttl            : parseInt(ttl, 10),
       class          : c,
       type           : type,
       'next domain'  : next,
-      'type bit maps': str.split(/\s+/).slice(5).filter(removeParens).join(' ').trim(),
+      'type bit maps': opts.bindline.split(/\s+/).slice(5).filter(removeParens).join(' ').trim(),
     })
   }
 
   /******  EXPORTERS   *******/
-  // toBind (zone_opts) {
-  //   return `${this.getPrefix(zone_opts)}\t${this.getFQDN('next domain', zone_opts)}\n`
-  // }
-
-  // toTinydns () {
-  // }
 }
 
 const removeParens = a => ![ '(',')' ].includes(a)

--- a/rr/ptr.js
+++ b/rr/ptr.js
@@ -32,9 +32,9 @@ export default class PTR extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // ^fqdn:p:ttl:timestamp:lo
-    const [ fqdn, p, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, p, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
 
     return new PTR({
       owner    : this.fullyQualify(fqdn),
@@ -46,9 +46,9 @@ export default class PTR extends RR {
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  PTR  dname
-    const [ owner, ttl, c, type, dname ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, dname ] = opts.bindline.split(/\s+/)
     return new PTR({
       owner,
       ttl  : parseInt(ttl, 10),

--- a/rr/smimea.js
+++ b/rr/smimea.js
@@ -55,9 +55,9 @@ export default class SMIMEA extends RR {
 
   /******  IMPORTERS   *******/
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  SMIMEA, usage, selector, match, data
-    const [ owner, ttl, c, type, usage, selector, match ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, usage, selector, match ] = opts.bindline.split(/\s+/)
     return new SMIMEA({
       owner,
       ttl                           : parseInt(ttl, 10),
@@ -66,7 +66,7 @@ export default class SMIMEA extends RR {
       'certificate usage'           : parseInt(usage,    10),
       selector                      : parseInt(selector, 10),
       'matching type'               : parseInt(match   , 10),
-      'certificate association data': str.split(/\s+/).slice(7).join(' ').trim(),
+      'certificate association data': opts.bindline.split(/\s+/).slice(7).join(' ').trim(),
     })
   }
 

--- a/rr/soa.js
+++ b/rr/soa.js
@@ -85,9 +85,9 @@ export default class SOA extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromBind (str) {
+  fromBind (opts) {
     // example.com TTL IN  SOA mname rname serial refresh retry expire minimum
-    const [ owner, ttl, c, type, mname, rname, serial, refresh, retry, expire, minimum ] = str.split(/[\s+]/)
+    const [ owner, ttl, c, type, mname, rname, serial, refresh, retry, expire, minimum ] = opts.bindline.split(/[\s+]/)
 
     return new SOA({
       owner,
@@ -104,9 +104,9 @@ export default class SOA extends RR {
     })
   }
 
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // Zfqdn:mname:rname:ser:ref:ret:exp:min:ttl:time:lo
-    const [ fqdn, mname, rname, ser, ref, ret, exp, min, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, mname, rname, ser, ref, ret, exp, min, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
 
     return new SOA({
       owner    : this.fullyQualify(fqdn),
@@ -114,7 +114,7 @@ export default class SOA extends RR {
       type     : 'SOA',
       mname    : this.fullyQualify(mname),
       rname    : this.fullyQualify(rname),
-      serial   : parseInt(ser, 10),
+      serial   : parseInt(ser || opts.default?.serial, 10),
       refresh  : parseInt(ref, 10) || 16384,
       retry    : parseInt(ret, 10) || 2048,
       expire   : parseInt(exp, 10) || 1048576,

--- a/rr/spf.js
+++ b/rr/spf.js
@@ -31,9 +31,9 @@ export default class SPF extends TXT {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // SPF via generic, :fqdn:n:rdata:ttl:timestamp:lo
-    const [ fqdn, n, rdata, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, n, rdata, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
     if (n != 99) throw new Error('SPF fromTinydns, invalid n')
 
     return new SPF({

--- a/rr/srv.js
+++ b/rr/srv.js
@@ -74,7 +74,7 @@ export default class SRV extends RR {
       pri    = TINYDNS.octalToUInt16(rdata.substring(0, 8))
       weight = TINYDNS.octalToUInt16(rdata.substring(8, 16))
       port   = TINYDNS.octalToUInt16(rdata.substring(16, 24))
-      addr   = TINYDNS.unpackDomainName(rdata.substring(24))
+      addr   = (TINYDNS.unpackDomainName(rdata.substring(24)))[0]
     }
 
     return new SRV({
@@ -84,7 +84,7 @@ export default class SRV extends RR {
       priority : parseInt(pri,    10),
       weight   : parseInt(weight, 10),
       port     : parseInt(port,   10),
-      target   : `${addr}.`,
+      target   : this.fullyQualify(addr),
       timestamp: ts,
       location : loc !== '' && loc !== '\n' ? loc : '',
     })

--- a/rr/srv.js
+++ b/rr/srv.js
@@ -58,7 +58,8 @@ export default class SRV extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
+    const str = opts.tinyline
     let fqdn, addr, port, pri, weight, ttl, ts, loc, n, rdata
 
     if (str[0] === 'S') {
@@ -89,9 +90,9 @@ export default class SRV extends RR {
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  SRV Priority Weight Port Target
-    const [ owner, ttl, c, type, pri, weight, port, target ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, pri, weight, port, target ] = opts.bindline.split(/\s+/)
     return new SRV({
       owner   : owner,
       ttl     : parseInt(ttl,    10),

--- a/rr/sshfp.js
+++ b/rr/sshfp.js
@@ -43,9 +43,9 @@ export default class SSHFP extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // SSHFP via generic, :fqdn:n:rdata:ttl:timestamp:lo
-    const [ fqdn, n, rdata, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, n, rdata, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
     if (n != 44) throw new Error('SSHFP fromTinydns, invalid n')
 
     const algo   = TINYDNS.octalToUInt16(rdata.substring(0, 8))
@@ -65,9 +65,9 @@ export default class SSHFP extends RR {
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  SSHFP  algo fptype fp
-    const [ owner, ttl, c, type, algo, fptype, fp ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, algo, fptype, fp ] = opts.bindline.split(/\s+/)
     return new SSHFP({
       owner,
       ttl        : parseInt(ttl, 10),

--- a/rr/tlsa.js
+++ b/rr/tlsa.js
@@ -54,10 +54,10 @@ export default class TLSA extends RR {
 
   /******  IMPORTERS   *******/
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  TLSA, usage, selector, match, data
-    const match = str.split(/^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+(.*?)\s*$/)
-    if (!match) throw new Error(`unable to parse TLSA: ${str}`)
+    const match = opts.bindline.split(/^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+(.*?)\s*$/)
+    if (!match) throw new Error(`unable to parse TLSA: ${opts.bindline}`)
     const [ owner, ttl, c, type, usage, selector, matchtype, cad ] = match.slice(1)
     return new TLSA({
       owner                         : this.fullyQualify(owner),

--- a/rr/tlsa.js
+++ b/rr/tlsa.js
@@ -80,15 +80,15 @@ export default class TLSA extends RR {
     const bytes = Buffer.from(TINYDNS.octalToChar(rdata), 'binary')
 
     return new TLSA({
-      owner        : this.fullyQualify(fqdn),
-      ttl          : parseInt(ttl, 10),
-      type         : 'TLSA',
-      'certificate usage': bytes.readUInt8(0),
-      selector           : bytes.readUInt8(1),
-      'matching type'    : bytes.readUInt8(2),
+      owner                         : this.fullyQualify(fqdn),
+      ttl                           : parseInt(ttl, 10),
+      type                          : 'TLSA',
+      'certificate usage'           : bytes.readUInt8(0),
+      selector                      : bytes.readUInt8(1),
+      'matching type'               : bytes.readUInt8(2),
       'certificate association data': bytes.slice(3).toString(),
-      timestamp    : ts,
-      location     : loc !== '' && loc !== '\n' ? loc : '',
+      timestamp                     : ts,
+      location                      : loc !== '' && loc !== '\n' ? loc : '',
     })
   }
 

--- a/rr/tlsa.js
+++ b/rr/tlsa.js
@@ -1,6 +1,8 @@
 
 import RR from '../rr.js'
 
+import * as TINYDNS from '../lib/tinydns.js'
+
 export default class TLSA extends RR {
   constructor (opts) {
     super(opts)
@@ -69,5 +71,36 @@ export default class TLSA extends RR {
       'matching type'               : parseInt(matchtype, 10),
       'certificate association data': cad,
     })
+  }
+
+  fromTinydns (opts) {
+    const [ fqdn, n, rdata, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
+    if (n != 52) throw new Error('TLSA fromTinydns, invalid n')
+
+    const bytes = Buffer.from(TINYDNS.octalToChar(rdata), 'binary')
+
+    return new TLSA({
+      owner        : this.fullyQualify(fqdn),
+      ttl          : parseInt(ttl, 10),
+      type         : 'TLSA',
+      'certificate usage': bytes.readUInt8(0),
+      selector           : bytes.readUInt8(1),
+      'matching type'    : bytes.readUInt8(2),
+      'certificate association data': bytes.slice(3).toString(),
+      timestamp    : ts,
+      location     : loc !== '' && loc !== '\n' ? loc : '',
+    })
+  }
+
+  /******  EXPORTERS   *******/
+  toTinydns () {
+    const dataRe = new RegExp(/[\r\n\t:\\/]/, 'g')
+
+    return this.getTinydnsGeneric(
+      TINYDNS.UInt8toOctal(this.get('certificate usage')) +
+      TINYDNS.UInt8toOctal(this.get('selector')) +
+      TINYDNS.UInt8toOctal(this.get('matching type')) +
+      TINYDNS.escapeOctal(dataRe, this.get('certificate association data'))
+    )
   }
 }

--- a/rr/txt.js
+++ b/rr/txt.js
@@ -30,7 +30,8 @@ export default class TXT extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
+    const str = opts.tinyline
     let fqdn, rdata, s, ttl, ts, loc
     // 'fqdn:s:ttl:timestamp:lo
     if (str[0] === "'") {
@@ -69,10 +70,10 @@ export default class TXT extends RR {
     return [ fqdn, s, ttl, ts, loc ]
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  TXT  "..."
-    const match = str.split(/^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+?\s*(.*?)\s*$/)
-    if (!match) throw new Error(`unable to parse TXT: ${str}`)
+    const match = opts.bindline.split(/^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+?\s*(.*?)\s*$/)
+    if (!match) throw new Error(`unable to parse TXT: ${opts.bindline}`)
     const [ owner, ttl, c, type, rdata ] = match.slice(1)
 
     return new this.constructor({

--- a/rr/uri.js
+++ b/rr/uri.js
@@ -1,5 +1,6 @@
 
 import RR from '../rr.js'
+
 import * as TINYDNS from '../lib/tinydns.js'
 
 export default class URI extends RR {

--- a/rr/uri.js
+++ b/rr/uri.js
@@ -27,9 +27,9 @@ export default class URI extends RR {
   }
 
   /******  IMPORTERS   *******/
-  fromTinydns (str) {
+  fromTinydns (opts) {
     // URI via generic, :fqdn:n:rdata:ttl:timestamp:lo
-    const [ fqdn, n, rdata, ttl, ts, loc ] = str.substring(1).split(':')
+    const [ fqdn, n, rdata, ttl, ts, loc ] = opts.tinyline.substring(1).split(':')
     if (n != 256) throw new Error('URI fromTinydns, invalid n')
 
     return new URI({
@@ -44,9 +44,9 @@ export default class URI extends RR {
     })
   }
 
-  fromBind (str) {
+  fromBind (opts) {
     // test.example.com  3600  IN  URI  priority, weight, target
-    const [ owner, ttl, c, type, priority, weight, target ] = str.split(/\s+/)
+    const [ owner, ttl, c, type, priority, weight, target ] = opts.bindline.split(/\s+/)
     return new URI({
       class   : c,
       type    : type,

--- a/test/base.js
+++ b/test/base.js
@@ -51,6 +51,7 @@ export function toBind (type, validRecords) {
 export function toTinydns (type, validRecords) {
   describe('toTinydns', function () {
     for (const val of validRecords) {
+      if (val.testT === undefined) continue
       it(`exports to tinydns: ${val.owner}`, async function () {
         const r = new type(val).toTinydns()
         if (process.env.DEBUG) console.dir(r)
@@ -81,8 +82,10 @@ export function getRFCs (type, valid) {
 
 function checkFromNS (type, validRecords, nsName, nsLineName) {
   for (const val of validRecords) {
+    const testLine = nsLineName === 'bindline' ? val.testB : val.testT
+    if (testLine == undefined) continue
     it(`imports ${nsName} record: ${val.owner}`, async function () {
-      const r = new type({ [nsLineName]: nsLineName === 'bindline' ? val.testB : val.testT })
+      const r = new type({ [nsLineName]: testLine })
       if (process.env.DEBUG) console.dir(r)
       for (const f of r.getFields()) {
         if (f === 'class') continue

--- a/test/dnskey.js
+++ b/test/dnskey.js
@@ -14,7 +14,7 @@ const validRecords = [
     algorithm: 5,
     publickey: `( AQPSKmynfzW4kyBv015MUG2DeIQ3 Cbl+BBZH4b/0PY1kxkmvHjcZc8no kfzj31GajIQKY+5CptLr3buXA10h WqTkF7H6RfoRqXQeogmMHfpftf6z Mv1LyBUgia7za6ZEzOJBOztyvhjL 742iU/TpPSEDhm2SNKLijfUppn1U aNvv4w== )`,
     testB    : 'example.com.\t3600\tIN\tDNSKEY\t256\t3\t5\t( AQPSKmynfzW4kyBv015MUG2DeIQ3 Cbl+BBZH4b/0PY1kxkmvHjcZc8no kfzj31GajIQKY+5CptLr3buXA10h WqTkF7H6RfoRqXQeogmMHfpftf6z Mv1LyBUgia7za6ZEzOJBOztyvhjL 742iU/TpPSEDhm2SNKLijfUppn1U aNvv4w== )\n',
-    testT    : ':dnskey.example.com:33:\\000\\001\\000\\000\\003\\341\\004mail\\007example\\003com\\000:3600::\n',
+    testT    : ':example.com:48:\\001\\000\\003\\005( AQPSKmynfzW4kyBv015MUG2DeIQ3 Cbl+BBZH4b\\0570PY1kxkmvHjcZc8no kfzj31GajIQKY+5CptLr3buXA10h WqTkF7H6RfoRqXQeogmMHfpftf6z Mv1LyBUgia7za6ZEzOJBOztyvhjL 742iU\\057TpPSEDhm2SNKLijfUppn1U aNvv4w== ):3600::\n',
   },
 ]
 
@@ -37,8 +37,8 @@ describe('DNSKEY record', function () {
   base.getTypeId(DNSKEY, 48)
 
   base.toBind(DNSKEY, validRecords)
-  // base.toTinydns(DNSKEY, validRecords)
+  base.toTinydns(DNSKEY, validRecords)
 
   base.fromBind(DNSKEY, validRecords)
-  // base.fromTinydns(DNSKEY, validRecords)
+  base.fromTinydns(DNSKEY, validRecords)
 })

--- a/test/ds.js
+++ b/test/ds.js
@@ -14,7 +14,7 @@ const validRecords = [
     'digest type': 1,
     digest       : `( 2BB183AF5F22588179A53B0A 98631FAD1A292118 )`,
     testB        : 'dskey.example.com.\t3600\tIN\tDS\t60485\t5\t1\t( 2BB183AF5F22588179A53B0A 98631FAD1A292118 )\n',
-    testT        : ':_imaps._tcp.example.com:33:\\000\\001\\000\\000\\003\\341\\004mail\\007example\\003com\\000:3600::\n',
+    testT        : ':dskey.example.com:43:\\354\\105\\005\\001( 2BB183AF5F22588179A53B0A 98631FAD1A292118 ):3600::\n',
   },
 ]
 
@@ -37,8 +37,8 @@ describe('DS record', function () {
   base.getTypeId(DS, 43)
 
   base.toBind(DS, validRecords)
-  // base.toTinydns(DS, validRecords)
+  base.toTinydns(DS, validRecords)
 
   base.fromBind(DS, validRecords)
-  // base.fromTinydns(DS, validRecords)
+  base.fromTinydns(DS, validRecords)
 })

--- a/test/ipseckey.js
+++ b/test/ipseckey.js
@@ -56,6 +56,18 @@ const validRecords = [
     publickey     : 'AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==',
     testB         : '0.d.4.0.3.0.e.f.f.f.3.f.0.1.2.0.1.0.0.0.0.0.2.8.b.d.0.1.0.0.2.ip6.arpa.\t7200\tIN\tIPSECKEY\t10\t2\t2\t2001:0db8:0:8002::2000:1\tAQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==\n',
   },
+  {
+    ...common,
+    owner         : 'ipsec.simerson.com.',
+    ttl           : 86400,
+    precedence    : 1,
+    'gateway type': 3,
+    algorithm     : 2,
+    gateway       : 'matt.simerson.net.',
+    publickey     : '0sAQPeOwAGDPLrDebL1q5Lg8XW9B/d9MnxqlzIYKXhvZPWEHNYGP7AwART/tmkeDNn7HPMtgM6GIwQ4p0KGLfSRoUKbjtPlRVeWYLbsnNXeFU5bchyYef0efYiKlxZdo',
+    testB         : 'ipsec.simerson.com.\t86400\tIN\tIPSECKEY\t1\t3\t2\tmatt.simerson.net.\t0sAQPeOwAGDPLrDebL1q5Lg8XW9B/d9MnxqlzIYKXhvZPWEHNYGP7AwART/tmkeDNn7HPMtgM6GIwQ4p0KGLfSRoUKbjtPlRVeWYLbsnNXeFU5bchyYef0efYiKlxZdo\n',
+    testT         : ':ipsec.simerson.com:45:\\001\\003\\002\\004matt\\010simerson\\003net\\000\\322\\300\\020\\075\\343\\260\\000\\140\\317.\\260\\336l\\275j\\344\\270\\074\\135oA\\375\\337L\\237\\032\\245\\314\\206\\012\\136\\033\\331\\075a\\0075\\201\\217\\354\\014\\000E\\077\\355\\232G\\2036\\176\\307\\074\\313\\1403\\241\\210\\301\\016\\051\\320\\241\\213\\175\\044hP\\246\\343\\264\\371QU\\345\\230-\\273\\0475w\\205S\\226\\334\\207\\046\\036\\177G\\237b\\042\\245\\305\\227h:86400::\n',
+  },
 ]
 
 const invalidRecords = [
@@ -72,8 +84,8 @@ describe('IPSECKEY record', function () {
   base.getTypeId(IPSECKEY, 45)
 
   base.toBind(IPSECKEY, validRecords)
-  // base.toTinydns(IPSECKEY, validRecords)
+  base.toTinydns(IPSECKEY, validRecords)
 
   base.fromBind(IPSECKEY, validRecords)
-  // base.fromTinydns(IPSECKEY, validRecords)
+  base.fromTinydns(IPSECKEY, validRecords)
 })

--- a/test/ipseckey.js
+++ b/test/ipseckey.js
@@ -15,6 +15,7 @@ const validRecords = [
     gateway       : '192.0.2.38',
     publickey     : 'AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==',
     testB         : '38.2.0.192.in-addr.arpa.\t7200\tIN\tIPSECKEY\t10\t1\t2\t192.0.2.38\tAQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==\n',
+    testT         : ':38.2.0.192.in-addr.arpa:45:\\012\\001\\002\\300\\000\\002\\046\\001\\003QSy\\206\\3555S\\073\\140dG\\216\\356\\262\\173\\133\\327M\\256\\024\\233n\\201\\272\\072\\005\\041\\257\\202\\253x\\001:7200::\n',
   },
   {
     ...common,
@@ -25,6 +26,7 @@ const validRecords = [
     gateway       : '.',
     publickey     : 'AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==',
     testB         : '38.2.0.192.in-addr.arpa.\t7200\tIN\tIPSECKEY\t10\t0\t2\t.\tAQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==\n',
+    testT         : ':38.2.0.192.in-addr.arpa:45:\\012\\000\\002.\\001\\003QSy\\206\\3555S\\073\\140dG\\216\\356\\262\\173\\133\\327M\\256\\024\\233n\\201\\272\\072\\005\\041\\257\\202\\253x\\001:7200::\n',
   },
   {
     ...common,
@@ -32,9 +34,10 @@ const validRecords = [
     precedence    : 10,
     'gateway type': 1,
     algorithm     : 2,
-    gateway       : '192.0.2.3',
+    gateway       : '192.0.2.38',
     publickey     : 'AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==',
-    testB         : '38.2.0.192.in-addr.arpa.\t7200\tIN\tIPSECKEY\t10\t1\t2\t192.0.2.3\tAQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==\n',
+    testB         : '38.2.0.192.in-addr.arpa.\t7200\tIN\tIPSECKEY\t10\t1\t2\t192.0.2.38\tAQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==\n',
+    testT         : ':38.2.0.192.in-addr.arpa:45:\\012\\001\\002\\300\\000\\002\\046\\001\\003QSy\\206\\3555S\\073\\140dG\\216\\356\\262\\173\\133\\327M\\256\\024\\233n\\201\\272\\072\\005\\041\\257\\202\\253x\\001:7200::\n',
   },
   {
     ...common,
@@ -45,6 +48,7 @@ const validRecords = [
     gateway       : 'mygateway.example.com.',
     publickey     : 'AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==',
     testB         : '38.1.0.192.in-addr.arpa.\t7200\tIN\tIPSECKEY\t10\t3\t2\tmygateway.example.com.\tAQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==\n',
+    testT         : ':38.1.0.192.in-addr.arpa:45:\\012\\003\\002\\011mygateway\\007example\\003com\\000\\001\\003QSy\\206\\3555S\\073\\140dG\\216\\356\\262\\173\\133\\327M\\256\\024\\233n\\201\\272\\072\\005\\041\\257\\202\\253x\\001:7200::\n',
   },
   {
     ...common,
@@ -71,11 +75,31 @@ const validRecords = [
 ]
 
 const invalidRecords = [
+  {
+    ...common,
+    owner         : '0.d.4.0.3.0.e.f.f.f.3.f.0.1.2.0.1.0.0.0.0.0.2.8.b.d.0.1.0.0.2.ip6.arpa.',
+    precedence    : 10,
+    'gateway type': 4,
+    algorithm     : 2,
+    gateway       : '2001:0db8:0:8002::2000:1',
+    publickey     : 'AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==',
+    msg           : /Gateway Type is invalid/,
+  },
+  {
+    ...common,
+    owner         : '0.d.4.0.3.0.e.f.f.f.3.f.0.1.2.0.1.0.0.0.0.0.2.8.b.d.0.1.0.0.2.ip6.arpa.',
+    precedence    : 10,
+    'gateway type': 3,
+    algorithm     : 3,
+    gateway       : '2001:0db8:0:8002::2000:1',
+    publickey     : 'AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==',
+    msg           : /Algorithm invalid/,
+  },
 ]
 
 describe('IPSECKEY record', function () {
   base.valid(IPSECKEY, validRecords)
-  base.invalid(IPSECKEY, invalidRecords, { ttl: 3600 })
+  base.invalid(IPSECKEY, invalidRecords)
 
   base.getDescription(IPSECKEY)
   base.getRFCs(IPSECKEY, validRecords[0])

--- a/test/naptr.js
+++ b/test/naptr.js
@@ -16,7 +16,7 @@ const validRecords = [
     regexp     : '!^urn:cid:.+@([^\\.]+\\.)(.*)$!\x02!i',
     replacement: '.',
     testB      : 'cid.urn.arpa.\t86400\tIN\tNAPTR\t100\t10\t""\t""\t"!^urn:cid:.+@([^\\.]+\\.)(.*)$!\x02!i"\t.\n',
-    testT      : ':cid.urn.arpa:35:\\000\\144\\000\\012\\000\\000\\040!^urn\\072cid\\072.+@([^\\134.]+\\134.)(.*)$!\x02!i\\001.``000:86400::\n',
+    testT      : ':cid.urn.arpa:35:\\000\\144\\000\\012\\000\\000\\040!^urn\\072cid\\072.+@([^\\134.]+\\134.)(.*)$!\x02!i\\001.\\000:86400::\n',
   },
 ]
 
@@ -36,5 +36,5 @@ describe('NAPTR record', function () {
   base.toTinydns(NAPTR, validRecords)
 
   base.fromBind(NAPTR, validRecords)
-  // base.fromTinydns(NAPTR, validRecords)
+  base.fromTinydns(NAPTR, validRecords)
 })

--- a/test/srv.js
+++ b/test/srv.js
@@ -9,14 +9,24 @@ const defaults = { class: 'IN', ttl: 3600, type: 'SRV' }
 
 const validRecords = [
   {
-    owner   : '_imaps._tcp.example.com.',
     ...defaults,
+    owner   : '_imaps._tcp.example.com.',
     priority: 1,
     weight  : 0,
     port    : 993,
     target  : 'mail.example.com.',
     testB   : '_imaps._tcp.example.com.\t3600\tIN\tSRV\t1\t0\t993\tmail.example.com.\n',
     testT   : ':_imaps._tcp.example.com:33:\\000\\001\\000\\000\\003\\341\\004mail\\007example\\003com\\000:3600::\n',
+  },
+  {
+    ...defaults,
+    owner   : '_sip._tls.example.com.',
+    priority: 100,
+    weight  : 1,
+    port    : 443,
+    target  : 'sipdir.online.lync.com.',
+    testB   : '_sip._tls.example.com.\t3600\tIN\tSRV\t100\t1\t443\tsipdir.online.lync.com.\n',
+    testT   : ':_sip._tls.example.com:33:\\000\\144\\000\\001\\001\\273\\006sipdir\\006online\\004lync\\003com\\000:3600::\n',
   },
 ]
 

--- a/test/sshfp.js
+++ b/test/sshfp.js
@@ -1,21 +1,44 @@
 
-import assert from 'assert'
-
 import * as base from './base.js'
 
 import SSHFP from '../rr/sshfp.js'
 
+const common = { type: 'SSHFP', ttl: 86400, class: 'IN' }
+
 const validRecords = [
   {
+    ...common,
     owner      : 'mail.example.com.',
-    ttl        : 86400,
-    class      : 'IN',
-    type       : 'SSHFP',
     algorithm  : 1,
     fptype     : 1,
     fingerprint: 'ed8c6e16fdae4f633eee6a7b8f64fdd356bbb32841d535565d777014c9ea4c26',
     testB      : 'mail.example.com.\t86400\tIN\tSSHFP\t1\t1\ted8c6e16fdae4f633eee6a7b8f64fdd356bbb32841d535565d777014c9ea4c26\n',
-    testT      : ':mail.example.com:44:\\000\\001\\000\\001\\355\\214\\156\\026\\375\\256\\117\\143\\076\\356\\152\\173\\217\\144\\375\\323\\126\\273\\263\\050\\101\\325\\065\\126\\135\\167\\160\\024\\311\\352\\114\\046:86400::\n',
+    testT      : ':mail.example.com:44:\\001\\001\\355\\214\\156\\026\\375\\256\\117\\143\\076\\356\\152\\173\\217\\144\\375\\323\\126\\273\\263\\050\\101\\325\\065\\126\\135\\167\\160\\024\\311\\352\\114\\046:86400::\n',
+  },
+  {
+    ...common,
+    owner      : 'jails.example.com.',
+    algorithm  : 1,
+    fptype     : 1,
+    fingerprint: '684981f1b57cc6b05bb2a5a7fd51a9114fef064d',
+    testB      : 'jails.example.com.\t86400\tIN\tSSHFP\t1\t1\t684981f1b57cc6b05bb2a5a7fd51a9114fef064d\n',
+    testT      : ':jails.example.com:44:\\001\\001\\150\\111\\201\\361\\265\\174\\306\\260\\133\\262\\245\\247\\375\\121\\251\\021\\117\\357\\006\\115:86400::\n',
+  },
+  {
+    ...common,
+    owner      : 'jails.example.com.',
+    algorithm  : 3,
+    fptype     : 2,
+    fingerprint: '81f9dbc4c009a1297336d69fcc2264f2a28417b781dafdd9c1ef7ff256066a35',
+    testB      : 'jails.example.com.\t86400\tIN\tSSHFP\t3\t2\t81f9dbc4c009a1297336d69fcc2264f2a28417b781dafdd9c1ef7ff256066a35\n',
+  },
+  {
+    ...common,
+    owner      : 'jails.example.com.',
+    algorithm  : 1,
+    fptype     : 2,
+    fingerprint: 'ed8c6e16fdae4f633eee6a7b8f64fdd356bbb32841d535565d777014c9ea4c26',
+    testB      : 'jails.example.com.\t86400\tIN\tSSHFP\t1\t2\ted8c6e16fdae4f633eee6a7b8f64fdd356bbb32841d535565d777014c9ea4c26\n',
   },
 ]
 
@@ -36,14 +59,4 @@ describe('SSHFP record', function () {
 
   base.fromBind(SSHFP, validRecords)
   base.fromTinydns(SSHFP, validRecords)
-
-  for (const val of validRecords) {
-    it.skip(`imports tinydns SSHFP (generic) record`, async function () {
-      const r = new SSHFP({ tinyline: val.testT })
-      if (process.env.DEBUG) console.dir(r)
-      for (const f of [ 'owner', 'algorithm', 'fptype', 'fingerprint', 'ttl' ]) {
-        assert.deepStrictEqual(r.get(f), val[f], `${f}: ${r.get(f)} !== ${val[f]}`)
-      }
-    })
-  }
 })

--- a/test/tinydns.js
+++ b/test/tinydns.js
@@ -99,7 +99,9 @@ describe('TINYDNS', function () {
 
   describe('unpackDomainName', function () {
     it(`extracts domain name from wire format`, async () => {
-      assert.strictEqual(TINYDNS.unpackDomainName('\\006sipdir\\006online\\004lync\\003com\\000'), 'sipdir.online.lync.com')
+      const r = TINYDNS.unpackDomainName('\\006sipdir\\006online\\004lync\\003com\\000')
+      assert.strictEqual(r[0], 'sipdir.online.lync.com.')
+      assert.strictEqual(r[1], 40)
     })
   })
 

--- a/test/tinydns.js
+++ b/test/tinydns.js
@@ -5,6 +5,27 @@ import * as TINYDNS from '../lib/tinydns.js'
 
 describe('TINYDNS', function () {
 
+  const b64cases = {
+    '0sAQPeOwAGDPLrDebL1q5Lg8XW9B/d9MnxqlzIYKXhvZPWEHNYGP7AwART/tmkeDNn7HPMtgM6GIwQ4p0KGLfSRoUKbjtPlRVeWYLbsnNXeFU5bchyYef0efYiKlxZdo':
+    '\\322\\300\\020\\075\\343\\260\\000\\140\\317.\\260\\336l\\275j\\344\\270\\074\\135oA\\375\\337L\\237\\032\\245\\314\\206\\012\\136\\033\\331\\075a\\0075\\201\\217\\354\\014\\000E\\077\\355\\232G\\2036\\176\\307\\074\\313\\1403\\241\\210\\301\\016\\051\\320\\241\\213\\175\\044hP\\246\\343\\264\\371QU\\345\\230-\\273\\0475w\\205S\\226\\334\\207\\046\\036\\177G\\237b\\042\\245\\305\\227h',
+  }
+
+  describe('base64toOctal', function () {
+    for (const c in b64cases) {
+      it('octal escapes a base64 encoded string', async function () {
+        assert.strictEqual(TINYDNS.base64toOctal(c), b64cases[c])
+      })
+    }
+  })
+
+  describe('octalToBase64', function () {
+    for (const c in b64cases) {
+      it('converts octal escaped to base64 encoded string', async function () {
+        assert.deepStrictEqual(TINYDNS.octalToBase64(b64cases[c]), c)
+      })
+    }
+  })
+
   describe('escapeOctal', function () {
 
     const rdataRe = new RegExp(/[\r\n\t:\\/]/, 'g')
@@ -21,10 +42,14 @@ describe('TINYDNS', function () {
 
     for (const c of Object.keys(specialChars)) {
       it(`escapes tinydns rdata special char ${c}`, function () {
-        const e = TINYDNS.escapeOctal(rdataRe, c)
-        assert.strictEqual(e, specialChars[c])
+        assert.strictEqual(TINYDNS.escapeOctal(rdataRe, c), specialChars[c])
       })
     }
+  })
+
+  describe('octaltoChar', function () {
+    it('converts a string of octal escapes to characters', async () => {
+    })
   })
 
   describe('octalToHex', function () {
@@ -70,5 +95,33 @@ describe('TINYDNS', function () {
     it('converts escaped octal to 32-bit integer', function () {
       assert.strictEqual(TINYDNS.octalToUInt32('\\145\\276\\224\\150'), 1706988648)
     })
+  })
+
+  describe('unpackDomainName', function () {
+    it(`extracts domain name from wire format`, async () => {
+      assert.strictEqual(TINYDNS.unpackDomainName('\\006sipdir\\006online\\004lync\\003com\\000'), 'sipdir.online.lync.com')
+    })
+  })
+
+  const cases = {
+    '0.0.0.0'        : '\\000\\000\\000\\000',
+    '192.0.2.127'    : '\\300\\000\\002\\177',
+    '255.255.255.255': '\\377\\377\\377\\377',
+  }
+
+  describe('ipv4toOctal', function () {
+    for (const c in cases) {
+      it(`converts dotted quad IPv4 to octal escaped integer ${c}`, async () => {
+        assert.strictEqual(TINYDNS.ipv4toOctal(c), cases[c])
+      })
+    }
+  })
+
+  describe('octalToIPv4', function () {
+    for (const c in cases) {
+      it(`converts octal escaped integer to dotted quad IPv4 ${cases[c]}`, async () => {
+        assert.strictEqual(TINYDNS.octalToIPv4(cases[c]), c)
+      })
+    }
   })
 })

--- a/test/tlsa.js
+++ b/test/tlsa.js
@@ -14,7 +14,7 @@ const validRecords = [
     'matching type'               : 1,
     'certificate association data': 'd2abde240d7cd3ee6b4b28c54df034b9 7983a1d16e8a410e4561cb106618e971',
     testB                         : '_443._tcp.www.example.com.\t3600\tIN\tTLSA\t0\t0\t1\td2abde240d7cd3ee6b4b28c54df034b9 7983a1d16e8a410e4561cb106618e971\n',
-    // testT              : '',
+    testT                         : ':_443._tcp.www.example.com:52:\\000\\000\\001d2abde240d7cd3ee6b4b28c54df034b9 7983a1d16e8a410e4561cb106618e971:3600::\n',
   },
   {
     ...defaults,
@@ -24,7 +24,7 @@ const validRecords = [
     'matching type'               : 2,
     'certificate association data': '92003ba34942dc74152e2f2c408d29ec a5a520e7f2e06bb944f4dca346baf63c 1b177615d466f6c4b71c216a50292bd5 8c9ebdd2f74e38fe51ffd48c43326cbc',
     testB                         : `_443._tcp.www.example.com.\t3600\tIN\tTLSA\t1\t1\t2\t92003ba34942dc74152e2f2c408d29ec a5a520e7f2e06bb944f4dca346baf63c 1b177615d466f6c4b71c216a50292bd5 8c9ebdd2f74e38fe51ffd48c43326cbc\n`,
-    testT                         : '',
+    testT                         : ':_443._tcp.www.example.com:52:\\001\\001\\00292003ba34942dc74152e2f2c408d29ec a5a520e7f2e06bb944f4dca346baf63c 1b177615d466f6c4b71c216a50292bd5 8c9ebdd2f74e38fe51ffd48c43326cbc:3600::\n',
   },
 ]
 
@@ -47,8 +47,8 @@ describe('TLSA record', function () {
   base.getTypeId(TLSA, 52)
 
   base.toBind(TLSA, validRecords)
-  // base.toTinydns(TLSA, validRecords)
+  base.toTinydns(TLSA, validRecords)
 
   base.fromBind(TLSA, validRecords)
-  // base.fromTinydns(TLSA, validRecords)
+  base.fromTinydns(TLSA, validRecords)
 })


### PR DESCRIPTION
- feat(tinydns): add ipv4toOctal, octalToIPv4, base64toOctal, octalToBase64
- feat(DNSKEY,DS,IPSECKEY,TLSA): added to/fromTinydns support
- feat(NAPTR): finished fromTinydns
- feat(bindline & tinyline): pass in opts (was only line), so defaults (serial, ttl, etc) can be passed in.
- fix(SSHFP): algo & fptype are 1 byte, not 2
- fix:(cname): fully qualify the target
- test: add tinydns.unpackDomainName, ipv4toOctal, octalToIPv4
- test(SRV): add another test case (found a bug in NicTool 2)
- test(IPSECKEY): expand test coverage
- tinydns.unpackdomain: return fqdn + length, for RRs where the FQDN is part of the byte stream