### PR TITLE
feat(throwHelp): far more useful error messages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ codecov.yml
 .codeclimate.yml
 test/
 DEVELOP.md
+.prettierrc.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Notable changes to this project are documented in this file.
 #### Unreleased
 
 - feat(SVCB,HTTPS): add record support
+- feat(throwHelp): far more useful error messages
+- feat(A,MX,AAAA,CAA): added getCanonical
 
 ### [1.2.0] - 2024-03-07
 

--- a/rr.js
+++ b/rr.js
@@ -128,7 +128,7 @@ export default class RR extends Map {
     if (this.constructor.name === 'RR') throw new Error(e)
 
     const example = this.getCanonical
-      ? `Example ${this.constructor.name}:\n${util.inspect(this.getCanonical(), { depth: null }).replace(/.*{/, '{')}\n\n`
+      ? `Example ${this.constructor.name}:\n${util.inspect(this.getCanonical(), { depth: null })}\n\n`
       : `${this.constructor.name} records have the fields: ${this.getFields().join(', ')}\n\n`
 
     throw new Error(`${e}\n\n${example}${this.citeRFC()}\n`)

--- a/rr.js
+++ b/rr.js
@@ -1,3 +1,5 @@
+import util from 'node:util'
+
 export default class RR extends Map {
   constructor(opts) {
     super()
@@ -21,7 +23,7 @@ export default class RR extends Map {
     for (const f of this.getFields('rdata')) {
       const fnName = `set${this.ucfirst(f)}`
       if (this[fnName] === undefined)
-        throw new Error(`Missing ${fnName} in class ${this.get('type')}`)
+        this.throwHelp(`Missing ${fnName} in class ${this.get('type')}`)
       this[fnName](opts[f])
     }
 
@@ -51,7 +53,7 @@ export default class RR extends Map {
         this.set('class', c)
         break
       default:
-        throw new Error(`invalid class ${c}`)
+        this.throwHelp(`invalid class ${c}`)
     }
   }
 
@@ -74,20 +76,20 @@ export default class RR extends Map {
   }
 
   setOwner(n) {
-    if (n === undefined) throw new Error(`owner is required`)
+    if (n === undefined) this.throwHelp(`owner is required`)
 
     if (n.length < 1 || n.length > 255)
-      throw new Error(
+      this.throwHelp(
         'Domain names must have 1-255 octets (characters): RFC 2181',
       )
 
-    this.isFullyQualified('', 'owner', n)
+    this.isFullyQualified(this.constructor.name, 'owner', n)
     this.hasValidLabels(n)
 
     // wildcard records: RFC 1034, 4592
     if (/\*/.test(n)) {
       if (!/^\*\./.test(n) && !/\.\*\./.test(n))
-        throw new Error('only *.something or * (by itself) is a valid wildcard')
+        this.throwHelp('only *.something or * (by itself) is a valid wildcard')
     }
 
     this.set('owner', n.toLowerCase())
@@ -97,11 +99,11 @@ export default class RR extends Map {
     if (t === undefined) t = this?.default?.ttl
     if (t === undefined) {
       if (['SOA', 'SSHPF'].includes(this.get('type'))) return
-      throw new Error('TTL is required, no default available')
+      this.throwHelp('TTL is required, no default available')
     }
 
     if (typeof t !== 'number')
-      throw new Error(`TTL must be numeric (${typeof t})`)
+      this.throwHelp(`TTL must be numeric (${typeof t})`)
 
     // RFC 1035, 2181
     this.is32bitInt(this.owner, 'TTL', t)
@@ -113,17 +115,27 @@ export default class RR extends Map {
     switch (t) {
       case '':
       case undefined:
-        throw new Error(`type is required`)
+        this.throwHelp(`type is required`)
     }
 
     if (t.toUpperCase() !== this.constructor.name)
-      throw new Error(`type ${t} doesn't match ${this.constructor.name}`)
+      this.throwHelp(`type ${t} doesn't match ${this.constructor.name}`)
 
     this.set('type', t.toUpperCase())
   }
 
+  throwHelp(e) {
+    if (this.constructor.name === 'RR') throw new Error(e)
+
+    const example = this.getCanonical
+      ? `Example ${this.constructor.name}:\n${util.inspect(this.getCanonical(), { depth: null }).replace(/.*{/, '{')}\n\n`
+      : `${this.constructor.name} records have the fields: ${this.getFields().join(', ')}\n\n`
+
+    throw new Error(`${e}\n\n${example}${this.citeRFC()}\n`)
+  }
+
   citeRFC() {
-    return `see RFC ${this.getRFCs()}`
+    return `see RFC${this.getRFCs().length > 1 ? 's' : ''} ${this.getRFCs()}`
   }
 
   fullyQualify(hostname, origin) {
@@ -194,7 +206,7 @@ export default class RR extends Map {
 
   getFQDN(field, zone_opts = {}) {
     let fqdn = this.get(field)
-    if (!fqdn) throw new Error(`empty value for field ${field}`)
+    if (!fqdn) this.throwHelp(`empty value for field ${field}`)
     if (!fqdn.endsWith('.')) fqdn += '.'
 
     if (zone_opts.hide?.origin && zone_opts.origin) {
@@ -235,7 +247,7 @@ export default class RR extends Map {
     const fq = hostname.endsWith('.') ? hostname.slice(0, -1) : hostname
     for (const label of fq.split('.')) {
       if (label.length < 1 || label.length > 63)
-        throw new Error('Labels must have 1-63 octets (characters), RFC 2181')
+        this.throwHelp('Labels must have 1-63 octets (characters), RFC 2181')
     }
   }
 
@@ -248,7 +260,7 @@ export default class RR extends Map {
     )
       return true
 
-    throw new Error(
+    this.throwHelp(
       `${type} ${field} must be a 8-bit integer (in the range 0-255)`,
     )
   }
@@ -262,7 +274,7 @@ export default class RR extends Map {
     )
       return true
 
-    throw new Error(
+    this.throwHelp(
       `${type} ${field} must be a 16-bit integer (in the range 0-65535)`,
     )
   }
@@ -276,7 +288,7 @@ export default class RR extends Map {
     )
       return true
 
-    throw new Error(
+    this.throwHelp(
       `${type} ${field} must be a 32-bit integer (in the range 0-2147483647)`,
     )
   }
@@ -285,10 +297,10 @@ export default class RR extends Map {
     return /^["']/.test(val) && /["']$/.test(val)
   }
 
-  isFullyQualified(type, blah, hostname) {
+  isFullyQualified(type, field, hostname) {
     if (hostname.endsWith('.')) return true
 
-    throw new Error(`${type}: ${blah} must be fully qualified`)
+    this.throwHelp(`${type}: ${field} must be fully qualified`)
   }
 
   isValidHostname(type, field, hostname) {
@@ -296,7 +308,7 @@ export default class RR extends Map {
     if (!allowed.test(hostname)) return true
 
     const matches = allowed.exec(hostname)
-    throw new Error(
+    this.throwHelp(
       `${type}, ${field} has invalid hostname character (${matches[0]})`,
     )
   }
@@ -320,7 +332,7 @@ export default class RR extends Map {
   }
 
   toMaraGeneric() {
-    // throw new Error(`\nMaraDNS does not support ${type} records yet and this package does not support MaraDNS generic records. Yet.\n`)
+    // this.throwHelp(`\nMaraDNS does not support ${type} records yet and this package does not support MaraDNS generic records. Yet.\n`)
     return `${this.get('owner')}\t+${this.get('ttl')}\tRAW ${this.getTypeId()}\t'${this.getRdataFields()
       .map((f) => this.getQuoted(f))
       .join(' ')}' ~\n`

--- a/rr/a.js
+++ b/rr/a.js
@@ -9,8 +9,8 @@ export default class A extends RR {
 
   /****** Resource record specific setters   *******/
   setAddress(val) {
-    if (!val) throw new Error('A: address is required')
-    if (!net.isIPv4(val)) throw new Error('A address must be IPv4')
+    if (!val) this.throwHelp('A: address is required')
+    if (!net.isIPv4(val)) this.throwHelp('A address must be IPv4')
     this.set('address', val)
   }
 
@@ -28,6 +28,16 @@ export default class A extends RR {
 
   getTypeId() {
     return 1
+  }
+
+  getCanonical() {
+    return new A({
+      owner: 'host.example.com.',
+      class: 'IN',
+      ttl: 3600,
+      type: 'A',
+      address: '192.0.2.127',
+    })
   }
 
   /******  IMPORTERS   *******/

--- a/rr/a.js
+++ b/rr/a.js
@@ -1,4 +1,4 @@
-import net from 'net'
+import net from 'node:net'
 
 import RR from '../rr.js'
 
@@ -31,13 +31,13 @@ export default class A extends RR {
   }
 
   getCanonical() {
-    return new A({
+    return {
       owner: 'host.example.com.',
       class: 'IN',
       ttl: 3600,
       type: 'A',
       address: '192.0.2.127',
-    })
+    }
   }
 
   /******  IMPORTERS   *******/

--- a/rr/aaaa.js
+++ b/rr/aaaa.js
@@ -10,8 +10,8 @@ export default class AAAA extends RR {
 
   /****** Resource record specific setters   *******/
   setAddress(val) {
-    if (!val) throw new Error('AAAA: address is required')
-    if (!net.isIPv6(val)) throw new Error(`AAAA: address must be IPv6 (${val})`)
+    if (!val) this.throwHelp('AAAA: address is required')
+    if (!net.isIPv6(val)) this.throwHelp(`AAAA: address must be IPv6 (${val})`)
 
     this.set('address', this.expand(val.toLowerCase())) // lower case: RFC 5952
   }
@@ -36,6 +36,16 @@ export default class AAAA extends RR {
     return 28
   }
 
+  getCanonical() {
+    return new AAAA({
+      owner: 'host.example.com.',
+      address: '2001:0db8:0020:000a:0000:0000:0000:0004',
+      class: 'IN',
+      ttl: 3600,
+      type: 'A',
+    })
+  }
+
   /******  IMPORTERS   *******/
   fromTinydns(opts) {
     const str = opts.tinyline
@@ -45,7 +55,7 @@ export default class AAAA extends RR {
       case ':':
         // GENERIC  =>  :fqdn:28:rdata:ttl:timestamp:lo
         ;[fqdn, n, rdata, ttl, ts, loc] = str.substring(1).split(':')
-        if (n != 28) throw new Error('AAAA fromTinydns, invalid n')
+        if (n != 28) this.throwHelp('AAAA fromTinydns, invalid n')
         ip = TINYDNS.octalToHex(rdata)
           .match(/([0-9a-fA-F]{4})/g)
           .join(':')

--- a/rr/aaaa.js
+++ b/rr/aaaa.js
@@ -1,4 +1,4 @@
-import net from 'net'
+import net from 'node:net'
 
 import RR from '../rr.js'
 import * as TINYDNS from '../lib/tinydns.js'
@@ -37,13 +37,13 @@ export default class AAAA extends RR {
   }
 
   getCanonical() {
-    return new AAAA({
+    return {
       owner: 'host.example.com.',
       address: '2001:0db8:0020:000a:0000:0000:0000:0004',
       class: 'IN',
       ttl: 3600,
       type: 'A',
-    })
+    }
   }
 
   /******  IMPORTERS   *******/

--- a/rr/caa.js
+++ b/rr/caa.js
@@ -70,7 +70,7 @@ export default class CAA extends RR {
   }
 
   getCanonical() {
-    return new CAA({
+    return {
       owner: 'example.com.',
       ttl: 3600,
       class: 'IN',
@@ -78,7 +78,7 @@ export default class CAA extends RR {
       flags: 0,
       tag: 'issue',
       value: 'http://letsencrypt.org',
-    })
+    }
   }
 
   /******  IMPORTERS   *******/

--- a/rr/caa.js
+++ b/rr/caa.js
@@ -11,7 +11,7 @@ export default class CAA extends RR {
     this.is8bitInt('CAA', 'flags', val)
 
     if (![0, 128].includes(val)) {
-      throw new Error(`CAA flags ${val} not recognized, ${this.citeRFC()}`)
+      this.throwHelp(`CAA flags ${val} not recognized`)
     }
 
     this.set('flags', val)
@@ -19,12 +19,12 @@ export default class CAA extends RR {
 
   setTag(val) {
     if (typeof val !== 'string' || val.length < 1 || /[^a-z0-9]/.test(val))
-      throw new Error(
-        `CAA tag must be a sequence of ASCII letters and numbers in lowercase, ${this.citeRFC()}`,
+      this.throwHelp(
+        `CAA tag must be a sequence of ASCII letters and numbers in lowercase`,
       )
 
     if (!['issue', 'issuewild', 'iodef'].includes(val)) {
-      throw new Error(`CAA tag ${val} not recognized: ${this.citeRFC()}`)
+      this.throwHelp(`CAA tag ${val} not recognized`)
     }
     this.set('tag', val)
   }
@@ -35,16 +35,14 @@ export default class CAA extends RR {
     if (this.isQuoted(val)) {
       val = val.replace(/^["']|["']$/g, '') // strip quotes
     } else {
-      // if (/\s/.test(val)) throw new Error(`CAA value may not have spaces unless quoted: RFC 8659`)
+      // if (/\s/.test(val)) this.throwHelp(`CAA value may not have spaces unless quoted`)
     }
 
     // check if val starts with one of iodefSchemes
     if (this.get('tag') === 'iodef') {
       const iodefSchemes = ['mailto:', 'http:', 'https:']
       if (!iodefSchemes.filter((s) => val.startsWith(s)).length) {
-        throw new Error(
-          `CAA value must have valid iodefScheme prefix, ${this.citeRFC()}`,
-        )
+        this.throwHelp(`CAA value must have valid iodefScheme prefix`)
       }
     }
 
@@ -71,11 +69,23 @@ export default class CAA extends RR {
     return 257
   }
 
+  getCanonical() {
+    return new CAA({
+      owner: 'example.com.',
+      ttl: 3600,
+      class: 'IN',
+      type: 'CAA',
+      flags: 0,
+      tag: 'issue',
+      value: 'http://letsencrypt.org',
+    })
+  }
+
   /******  IMPORTERS   *******/
   fromTinydns(opts) {
     // CAA via generic, :fqdn:n:rdata:ttl:timestamp:lo
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 257) throw new Error('CAA fromTinydns, invalid n')
+    if (n != 257) this.throwHelp('CAA fromTinydns, invalid n')
 
     const flags = TINYDNS.octalToUInt8(rdata.substring(0, 4))
     const taglen = TINYDNS.octalToUInt8(rdata.substring(4, 8))
@@ -101,7 +111,7 @@ export default class CAA extends RR {
     const fields = opts.bindline.match(
       /^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+([0-9]+)\s+(\w+)\s+("[^"]+"|[^\s]+?)\s*$/i,
     )
-    if (!fields) throw new Error(`unable to parse: ${opts.bindline}`)
+    if (!fields) this.throwHelp(`unable to parse: ${opts.bindline}`)
 
     const [owner, ttl, c, type, flags, tag, value] = fields.slice(1)
     return new CAA({

--- a/rr/cname.js
+++ b/rr/cname.js
@@ -12,10 +12,10 @@ export default class CNAME extends RR {
     // A <domain-name> which specifies the canonical or primary
     // name for the owner.  The owner name is an alias.
 
-    if (!val) throw new Error('CNAME: cname is required')
+    if (!val) this.throwHelp('CNAME: cname is required')
 
     if (net.isIPv4(val) || net.isIPv6(val))
-      throw new Error(`CNAME: cname must be a FQDN: RFC 2181`)
+      this.throwHelp(`CNAME: cname must be a FQDN: RFC 2181`)
 
     if (!this.isFullyQualified('CNAME', 'cname', val)) return
     if (!this.isValidHostname('CNAME', 'cname', val)) return

--- a/rr/cname.js
+++ b/rr/cname.js
@@ -1,4 +1,4 @@
-import net from 'net'
+import net from 'node:net'
 
 import RR from '../rr.js'
 

--- a/rr/dname.js
+++ b/rr/dname.js
@@ -1,4 +1,4 @@
-import net from 'net'
+import net from 'node:net'
 
 import RR from '../rr.js'
 import * as TINYDNS from '../lib/tinydns.js'

--- a/rr/dname.js
+++ b/rr/dname.js
@@ -10,10 +10,10 @@ export default class DNAME extends RR {
 
   /****** Resource record specific setters   *******/
   setTarget(val) {
-    if (!val) throw new Error('DNAME: target is required')
+    if (!val) this.throwHelp('DNAME: target is required')
 
     if (net.isIPv4(val) || net.isIPv6(val))
-      throw new Error(`DNAME: target must be a domain name, ${this.citeRFC()}`)
+      this.throwHelp(`DNAME: target must be a domain name`)
 
     this.isFullyQualified('DNAME', 'target', val)
     this.isValidHostname('DNAME', 'target', val)
@@ -42,7 +42,7 @@ export default class DNAME extends RR {
   fromTinydns(opts) {
     // DNAME via generic, :fqdn:n:rdata:ttl:timestamp:lo
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 39) throw new Error('DNAME fromTinydns, invalid n')
+    if (n != 39) this.throwHelp('DNAME fromTinydns, invalid n')
 
     return new DNAME({
       type: 'DNAME',

--- a/rr/dnskey.js
+++ b/rr/dnskey.js
@@ -13,8 +13,7 @@ export default class DNSKEY extends RR {
     this.is16bitInt('DNSKEY', 'flags', val)
 
     // the possible values are: 0, 256, and 257; RFC 4034
-    if (![0, 256, 257].includes(val))
-      throw new Error(`DNSKEY: flags invalid, ${this.citeRFC()}`)
+    if (![0, 256, 257].includes(val)) this.throwHelp(`DNSKEY: flags invalid`)
 
     this.set('flags', val)
   }
@@ -24,8 +23,7 @@ export default class DNSKEY extends RR {
     this.is8bitInt('DNSKEY', 'protocol', val)
 
     // The Protocol Field MUST be represented as an unsigned decimal integer with a value of 3.
-    if (![3].includes(val))
-      throw new Error(`DNSKEY: protocol invalid, ${this.citeRFC()}`)
+    if (![3].includes(val)) this.throwHelp(`DNSKEY: protocol invalid`)
 
     this.set('protocol', val)
   }
@@ -37,16 +35,13 @@ export default class DNSKEY extends RR {
     // https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
     // 1=RSA/MD5, 2=DH, 3=DSA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![...Array(16).keys(), 253, 254].includes(val))
-      console.error(
-        `DNSKEY: algorithm (${val}) not recognized, ${this.citeRFC()}`,
-      )
+      console.error(`DNSKEY: algorithm (${val}) not recognized`)
 
     this.set('algorithm', val)
   }
 
   setPublickey(val) {
-    if (!val)
-      throw new Error(`DNSKEY: publickey is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`DNSKEY: publickey is required`)
 
     this.set('publickey', val)
   }
@@ -74,7 +69,7 @@ export default class DNSKEY extends RR {
     const match = opts.bindline.match(
       /^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+\s*(.*?)\s*$/,
     )
-    if (!match) throw new Error(`unable to parse DNSKEY: ${opts.bindline}`)
+    if (!match) this.throwHelp(`unable to parse DNSKEY: ${opts.bindline}`)
     const [owner, ttl, c, type, flags, protocol, algorithm, publickey] =
       match.slice(1)
 
@@ -92,7 +87,7 @@ export default class DNSKEY extends RR {
 
   fromTinydns(opts) {
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 48) throw new Error('DNSKEY fromTinydns, invalid n')
+    if (n != 48) this.throwHelp('DNSKEY fromTinydns, invalid n')
 
     const bytes = Buffer.from(TINYDNS.octalToChar(rdata), 'binary')
 

--- a/rr/ds.js
+++ b/rr/ds.js
@@ -10,9 +10,8 @@ export default class DS extends RR {
   /****** Resource record specific setters   *******/
   setKeyTag(val) {
     // a 2 octet Key Tag field...in network byte order
-    if (!val) throw new Error(`DS: key tag is required`)
-    if (val.length > 2)
-      throw new Error(`DS: key tag is too long, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`DS: key tag is required`)
+    if (val.length > 2) this.throwHelp(`DS: key tag is too long`)
 
     this.set('key tag', val)
   }
@@ -20,20 +19,19 @@ export default class DS extends RR {
   setAlgorithm(val) {
     // 1=RSA/MD5, 2=DH, 3=DSA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![1, 2, 3, 4, 5, 253, 254].includes(val))
-      throw new Error(`DS: algorithm invalid, ${this.citeRFC()}`)
+      this.throwHelp(`DS: algorithm invalid`)
 
     this.set('algorithm', val)
   }
 
   setDigestType(val) {
-    if (![1, 2].includes(val))
-      throw new Error(`DS: digest type invalid, ${this.citeRFC()}`)
+    if (![1, 2].includes(val)) this.throwHelp(`DS: digest type invalid`)
 
     this.set('digest type', val)
   }
 
   setDigest(val) {
-    if (!val) throw new Error(`DS: digest is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`DS: digest is required`)
 
     this.set('digest', val)
   }
@@ -74,7 +72,7 @@ export default class DS extends RR {
 
   fromTinydns(opts) {
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 43) throw new Error('DS fromTinydns, invalid n')
+    if (n != 43) this.throwHelp('DS fromTinydns, invalid n')
 
     const binRdata = Buffer.from(TINYDNS.octalToChar(rdata), 'binary')
 

--- a/rr/hinfo.js
+++ b/rr/hinfo.js
@@ -9,12 +9,12 @@ export default class HINFO extends RR {
 
   /****** Resource record specific setters   *******/
   setCpu(val) {
-    if (val.length > 255) throw new Error('HINFO cpu cannot exceed 255 chars')
+    if (val.length > 255) this.throwHelp('HINFO cpu cannot exceed 255 chars')
     this.set('cpu', val.replace(/^["']|["']$/g, ''))
   }
 
   setOs(val) {
-    if (val.length > 255) throw new Error('HINFO os cannot exceed 255 chars')
+    if (val.length > 255) this.throwHelp('HINFO os cannot exceed 255 chars')
     this.set('os', val.replace(/^["']|["']$/g, ''))
   }
 
@@ -44,7 +44,7 @@ export default class HINFO extends RR {
     const match = opts.bindline.match(
       /([^\s]+)\s+([0-9]+)\s+(IN)\s+(HINFO)\s+("[^"]+"|[^\s]+)\s+("[^"]+"|[^\s]+)/i,
     )
-    if (!match) throw new Error(`unable to parse HINFO: ${opts.bindline}`)
+    if (!match) this.throwHelp(`unable to parse HINFO: ${opts.bindline}`)
     const [owner, ttl, c, type, cpu, os] = match.slice(1)
 
     return new HINFO({

--- a/rr/https.js
+++ b/rr/https.js
@@ -21,7 +21,7 @@ export default class HTTPS extends RR {
   }
 
   setParams(val) {
-    // if (!val) throw new Error(`HTTPS: params is required, ${this.citeRFC()}`)
+    // if (!val) this.throwHelp(`HTTPS: params is required`)
 
     this.set('params', val)
   }

--- a/rr/ipseckey.js
+++ b/rr/ipseckey.js
@@ -20,23 +20,20 @@ export default class IPSECKEY extends RR {
   setGatewayType(val) {
     // 0 (none), 1 (4-byte IPv4), 2 (16-byte IPv6), 3 (wire encoded domain name)
     if (![0, 1, 2, 3].includes(val))
-      throw new Error(`IPSECKEY: Gateway Type is invalid, ${this.citeRFC()}`)
+      this.throwHelp(`IPSECKEY: Gateway Type is invalid`)
 
     this.set('gateway type', val)
   }
 
   setAlgorithm(val) {
     // unsigned int, 1 octet, values: 1=DSA, 2=RSA
-    if (![1, 2].includes(val))
-      throw new Error(`IPSECKEY: Algorithm invalid, ${this.citeRFC()}`)
+    if (![1, 2].includes(val)) this.throwHelp(`IPSECKEY: Algorithm invalid`)
 
     this.set('algorithm', val)
   }
 
   setGateway(val) {
-    const gwErr = new Error(
-      `IPSECKEY: gateway invalid (${val}), ${this.citeRFC()}`,
-    )
+    const gwErr = new Error(`IPSECKEY: gateway invalid (${val})`)
     switch (this.get('gateway type')) {
       case 0:
         if (val !== '.') throw gwErr
@@ -53,7 +50,7 @@ export default class IPSECKEY extends RR {
   }
 
   setPublickey(val) {
-    // if (val) throw new Error(`IPSECKEY: publickey is optional, ${this.citeRFC()}`)
+    // if (val) this.throwHelp(`IPSECKEY: publickey is optional`)
 
     this.set('publickey', val)
   }
@@ -94,7 +91,7 @@ export default class IPSECKEY extends RR {
 
   fromTinydns(opts) {
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 45) throw new Error('IPSECKEY fromTinydns, invalid n')
+    if (n != 45) this.throwHelp('IPSECKEY fromTinydns, invalid n')
 
     const precedence = TINYDNS.octalToUInt8(rdata.substring(0, 4))
     const gwType = TINYDNS.octalToUInt8(rdata.substring(4, 8))

--- a/rr/ipseckey.js
+++ b/rr/ipseckey.js
@@ -1,4 +1,4 @@
-import net from 'net'
+import net from 'node:net'
 
 import RR from '../rr.js'
 

--- a/rr/key.js
+++ b/rr/key.js
@@ -24,13 +24,13 @@ export default class KEY extends RR {
     // 1 octet
     // 1=RSA/MD5, 2=DH, 3=DSA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![1, 2, 3, 4, 5, 253, 254].includes(val))
-      throw new Error(`KEY: algorithm invalid, ${this.citeRFC()}`)
+      this.throwHelp(`KEY: algorithm invalid`)
 
     this.set('algorithm', val)
   }
 
   setPublickey(val) {
-    if (!val) throw new Error(`KEY: publickey is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`KEY: publickey is required`)
 
     this.set('publickey', val)
   }

--- a/rr/loc.js
+++ b/rr/loc.js
@@ -20,7 +20,7 @@ export default class LOC extends RR {
 
   /****** Resource record specific setters   *******/
   setAddress(val) {
-    if (!val) throw new Error('LOC: address is required')
+    if (!val) this.throwHelp('LOC: address is required')
 
     /*
     ... LOC ( d1 [m1 [s1]] {"N"|"S"} d2 [m2 [s2]]
@@ -59,7 +59,7 @@ export default class LOC extends RR {
     // put them all together
     const locRe = new RegExp(`^${dms}(N|S)\\s+${dms}(E|W)\\s+${alt}`, 'i')
     const r = string.match(locRe)
-    if (!r) throw new Error('LOC address: invalid format, see RFC 1876')
+    if (!r) this.throwHelp('LOC address: invalid format, see RFC 1876')
 
     const loc = {
       latitude: {
@@ -89,7 +89,7 @@ export default class LOC extends RR {
   fromTinydns(opts) {
     // LOC via generic, :fqdn:n:rdata:ttl:timestamp:lo
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 29) throw new Error('LOC fromTinydns, invalid n')
+    if (n != 29) this.throwHelp('LOC fromTinydns, invalid n')
 
     // divide by 100 is to convert cm to meters
     const l = {
@@ -173,7 +173,7 @@ export default class LOC extends RR {
         hem = rawmsec >= REF.LATLON ? 'E' : 'W'
         break
       default:
-        throw new Error('unknown or missing hemisphere')
+        this.throwHelp('unknown or missing hemisphere')
     }
 
     return `${deg} ${min} ${sec}${msec ? '.' + msec : ''} ${hem}`

--- a/rr/mx.js
+++ b/rr/mx.js
@@ -10,15 +10,16 @@ export default class MX extends RR {
   /****** Resource record specific setters   *******/
   setPreference(val) {
     if (val === undefined) val = this?.default?.preference
+    if (val === undefined) this.throwHelp('MX: preference is required')
     this.is16bitInt('MX', 'preference', val)
     this.set('preference', val)
   }
 
   setExchange(val) {
-    if (!val) throw new Error('MX: exchange is required')
+    if (!val) this.throwHelp('MX: exchange is required')
 
     if (net.isIPv4(val) || net.isIPv6(val))
-      throw new Error(`MX: exchange must be a FQDN, ${this.citeRFC()}`)
+      this.throwHelp(`MX: exchange must be a FQDN`)
 
     this.isFullyQualified('MX', 'exchange', val)
     this.isValidHostname('MX', 'exchange', val)
@@ -41,6 +42,17 @@ export default class MX extends RR {
 
   getTypeId() {
     return 15
+  }
+
+  getCanonical() {
+    return new MX({
+      owner: 'example.com.',
+      ttl: 43200,
+      class: 'IN',
+      type: 'MX',
+      preference: 0,
+      exchange: 'mail.example.com.',
+    })
   }
 
   /******  IMPORTERS   *******/

--- a/rr/mx.js
+++ b/rr/mx.js
@@ -1,4 +1,4 @@
-import net from 'net'
+import net from 'node:net'
 
 import RR from '../rr.js'
 
@@ -45,14 +45,14 @@ export default class MX extends RR {
   }
 
   getCanonical() {
-    return new MX({
+    return {
       owner: 'example.com.',
       ttl: 43200,
       class: 'IN',
       type: 'MX',
       preference: 0,
       exchange: 'mail.example.com.',
-    })
+    }
   }
 
   /******  IMPORTERS   *******/

--- a/rr/naptr.js
+++ b/rr/naptr.js
@@ -41,7 +41,7 @@ export default class NAPTR extends RR {
 
   setFlags(val) {
     if (!['', 'S', 'A', 'U', 'P'].includes(val.toUpperCase()))
-      throw new Error(`NAPTR flags are invalid, ${this.citeRFC()}`)
+      this.throwHelp(`NAPTR flags are invalid`)
 
     this.set('flags', val.toUpperCase())
   }
@@ -62,7 +62,7 @@ export default class NAPTR extends RR {
   fromTinydns(opts) {
     // NAPTR via generic, :fqdn:n:rdata:ttl:timestamp:lo
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 35) throw new Error('NAPTR fromTinydns, invalid n')
+    if (n != 35) this.throwHelp('NAPTR fromTinydns, invalid n')
 
     const binRdata = Buffer.from(TINYDNS.octalToChar(rdata), 'binary')
 

--- a/rr/ns.js
+++ b/rr/ns.js
@@ -8,7 +8,7 @@ export default class NS extends RR {
 
   /****** Resource record specific setters   *******/
   setDname(val) {
-    if (!val) throw new Error(`NS: dname is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NS: dname is required`)
 
     this.isFullyQualified('NS', 'dname', val)
     this.isValidHostname('NS', 'dname', val)

--- a/rr/nsec.js
+++ b/rr/nsec.js
@@ -8,8 +8,7 @@ export default class NSEC extends RR {
 
   /****** Resource record specific setters   *******/
   setNextDomain(val) {
-    if (!val)
-      throw new Error(`NSEC: 'next domain' is required:, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NSEC: 'next domain' is required:`)
 
     this.isFullyQualified('NSEC', 'next domain', val)
     this.isValidHostname('NSEC', 'next domain', val)
@@ -19,8 +18,7 @@ export default class NSEC extends RR {
   }
 
   setTypeBitMaps(val) {
-    if (!val)
-      throw new Error(`NSEC: 'type bit maps' is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NSEC: 'type bit maps' is required`)
 
     this.set('type bit maps', val)
   }

--- a/rr/nsec3.js
+++ b/rr/nsec3.js
@@ -12,8 +12,7 @@ export default class NSEC3 extends RR {
   setHashAlgorithm(val) {
     // Hash Algorithm is a single octet.
     // The Hash Algorithm field is represented as an unsigned decimal integer.
-    if (!val)
-      throw new Error(`NSEC3: 'hash algorithm' is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NSEC3: 'hash algorithm' is required`)
 
     this.is8bitInt('NSEC3', 'hash algorithm', val)
 
@@ -22,7 +21,7 @@ export default class NSEC3 extends RR {
 
   setFlags(val) {
     // The Flags field is represented as an unsigned decimal integer.
-    if (!val) throw new Error(`NSEC3: 'flags' is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NSEC3: 'flags' is required`)
 
     this.is8bitInt('NSEC3', 'flags', val)
 
@@ -31,8 +30,7 @@ export default class NSEC3 extends RR {
 
   setIterations(val) {
     // The Iterations field is represented as an unsigned decimal integer. 0-65535
-    if (!val)
-      throw new Error(`NSEC3: 'iterations' is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NSEC3: 'iterations' is required`)
 
     this.is16bitInt('NSEC3', 'flags', val)
 
@@ -50,18 +48,14 @@ export default class NSEC3 extends RR {
   setNextHashedOwnerName(val) {
     // The Next Hashed Owner Name field is represented as an unpadded
     // sequence of case-insensitive base32 digits, without whitespace
-    if (!val)
-      throw new Error(
-        `NSEC3: 'next hashed owner name' is required, ${this.citeRFC()}`,
-      )
+    if (!val) this.throwHelp(`NSEC3: 'next hashed owner name' is required`)
 
     this.set('next hashed owner name', val)
   }
 
   setTypeBitMaps(val) {
     // The Type Bit Maps field is represented as a sequence of RR type mnemonics.
-    if (!val)
-      throw new Error(`NSEC3: 'type bit maps' is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NSEC3: 'type bit maps' is required`)
 
     this.set('type bit maps', val)
   }
@@ -113,7 +107,7 @@ export default class NSEC3 extends RR {
 
   fromTinydns(opts) {
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 50) throw new Error('NSEC3 fromTinydns, invalid n')
+    if (n != 50) this.throwHelp('NSEC3 fromTinydns, invalid n')
 
     const bytes = Buffer.from(TINYDNS.octalToChar(rdata), 'binary')
 

--- a/rr/nsec3param.js
+++ b/rr/nsec3param.js
@@ -10,10 +10,7 @@ export default class NSEC3PARAM extends RR {
   setHashAlgoritm(val) {
     // Hash Algorithm is a single octet.
     // The Hash Algorithm field is represented as an unsigned decimal integer.
-    if (!val)
-      throw new Error(
-        `NSEC3PARAM: 'hash algorithm' is required, ${this.citeRFC()}`,
-      )
+    if (!val) this.throwHelp(`NSEC3PARAM: 'hash algorithm' is required`)
 
     this.is8bitInt('NSEC3PARAM', 'hash algorithm', val)
 
@@ -22,8 +19,7 @@ export default class NSEC3PARAM extends RR {
 
   setFlags(val) {
     // The Flags field is represented as an unsigned decimal integer.
-    if (!val)
-      throw new Error(`NSEC3PARAM: 'flags' is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NSEC3PARAM: 'flags' is required`)
 
     this.is8bitInt('NSEC3PARAM', 'flags', val)
 
@@ -32,8 +28,7 @@ export default class NSEC3PARAM extends RR {
 
   setIterations(val) {
     // The Iterations field is represented as an unsigned decimal integer. 0-65535
-    if (!val)
-      throw new Error(`NSEC3PARAM: 'iterations' is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NSEC3PARAM: 'iterations' is required`)
 
     this.is16bitInt('NSEC3PARAM', 'iterations', val)
 

--- a/rr/nxt.js
+++ b/rr/nxt.js
@@ -8,8 +8,7 @@ export default class NXT extends RR {
 
   /****** Resource record specific setters   *******/
   setNextDomain(val) {
-    if (!val)
-      throw new Error(`NXT: 'next domain' is required:, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NXT: 'next domain' is required`)
 
     this.isFullyQualified('NXT', 'next domain', val)
     this.isValidHostname('NXT', 'next domain', val)
@@ -19,8 +18,7 @@ export default class NXT extends RR {
   }
 
   setTypeBitMap(val) {
-    if (!val)
-      throw new Error(`NXT: 'type bit map' is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`NXT: 'type bit map' is required`)
 
     this.set('type bit map', val)
   }

--- a/rr/rrsig.js
+++ b/rr/rrsig.js
@@ -8,9 +8,8 @@ export default class RRSIG extends RR {
   /****** Resource record specific setters   *******/
   setTypeCovered(val) {
     // a 2 octet Type Covered field
-    if (!val) throw new Error(`RRSIG: 'type covered' is required`)
-    if (val.length > 2)
-      throw new Error(`RRSIG: 'type covered' is too long, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`RRSIG: 'type covered' is required`)
+    if (val.length > 2) this.throwHelp(`RRSIG: 'type covered' is too long`)
 
     this.set('type covered', val)
   }
@@ -19,7 +18,7 @@ export default class RRSIG extends RR {
     // a 1 octet Algorithm field
     // 1=RSA/MD5, 2=DH, 3=RRSIGA/SHA-1, 4=EC, 5=RSA/SHA-1
     if (![1, 2, 3, 4, 5, 253, 254].includes(val))
-      throw new Error(`RRSIG: algorithm invalid, ${this.citeRFC()}`)
+      this.throwHelp(`RRSIG: algorithm invalid`)
 
     this.set('algorithm', val)
   }

--- a/rr/sig.js
+++ b/rr/sig.js
@@ -8,7 +8,7 @@ export default class SIG extends RR {
   /****** Resource record specific setters   *******/
   setTypeCovered(val) {
     // a 2 octet Type Covered field
-    if (!val) throw new Error(`SIG: 'type covered' is required`)
+    if (!val) this.throwHelp(`SIG: 'type covered' is required`)
 
     this.set('type covered', val)
   }

--- a/rr/smimea.js
+++ b/rr/smimea.js
@@ -8,21 +8,19 @@ export default class SMIMEA extends RR {
   /****** Resource record specific setters   *******/
   setCertificateUsage(val) {
     if (![0, 1, 2, 3].includes(val))
-      throw new Error(`SMIMEA: certificate usage invalid, ${this.citeRFC()}`)
+      this.throwHelp(`SMIMEA: certificate usage invalid`)
 
     this.set('certificate usage', val)
   }
 
   setSelector(val) {
-    if (![0, 1].includes(val))
-      throw new Error(`SMIMEA: selector invalid, ${this.citeRFC()}`)
+    if (![0, 1].includes(val)) this.throwHelp(`SMIMEA: selector invalid`)
 
     this.set('selector', val)
   }
 
   setMatchingType(val) {
-    if (![0, 1, 2].includes(val))
-      throw new Error(`SMIMEA: matching type, ${this.citeRFC()}`)
+    if (![0, 1, 2].includes(val)) this.throwHelp(`SMIMEA: matching type`)
 
     this.set('matching type', val)
   }

--- a/rr/soa.js
+++ b/rr/soa.js
@@ -28,8 +28,7 @@ export default class SOA extends RR {
     // RNAME (email of admin)  (escape . with \)
     this.isValidHostname('SOA', 'RNAME', val)
     this.isFullyQualified('SOA', 'RNAME', val)
-    if (/@/.test(val))
-      throw new Error(`SOA rname replaces @ with a . (dot), ${this.citeRFC()}`)
+    if (/@/.test(val)) this.throwHelp(`SOA rname replaces @ with a . (dot)`)
 
     // RFC 4034: letters in the DNS names are lower cased
     this.set('rname', val.toLowerCase())

--- a/rr/spf.js
+++ b/rr/spf.js
@@ -34,7 +34,7 @@ export default class SPF extends TXT {
   fromTinydns(opts) {
     // SPF via generic, :fqdn:n:rdata:ttl:timestamp:lo
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 99) throw new Error('SPF fromTinydns, invalid n')
+    if (n != 99) this.throwHelp('SPF fromTinydns, invalid n')
 
     return new SPF({
       type: 'SPF',

--- a/rr/srv.js
+++ b/rr/srv.js
@@ -1,4 +1,4 @@
-import net from 'net'
+import net from 'node:net'
 
 import RR from '../rr.js'
 import * as TINYDNS from '../lib/tinydns.js'

--- a/rr/srv.js
+++ b/rr/srv.js
@@ -28,10 +28,10 @@ export default class SRV extends RR {
   }
 
   setTarget(val) {
-    if (!val) throw new Error(`SRV: target is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`SRV: target is required`)
 
     if (net.isIPv4(val) || net.isIPv6(val))
-      throw new Error(`SRV: target must be a FQDN, ${this.citeRFC()}`)
+      this.throwHelp(`SRV: target must be a FQDN`)
 
     this.isFullyQualified('SRV', 'target', val)
     this.isValidHostname('SRV', 'target', val)
@@ -69,7 +69,7 @@ export default class SRV extends RR {
     } else {
       // tinydns generic record format
       ;[fqdn, n, rdata, ttl, ts, loc] = str.substring(1).split(':')
-      if (n != 33) throw new Error('SRV fromTinydns: invalid n')
+      if (n != 33) this.throwHelp('SRV fromTinydns: invalid n')
 
       pri = TINYDNS.octalToUInt16(rdata.substring(0, 8))
       weight = TINYDNS.octalToUInt16(rdata.substring(8, 16))

--- a/rr/sshfp.js
+++ b/rr/sshfp.js
@@ -45,7 +45,7 @@ export default class SSHFP extends RR {
   fromTinydns(opts) {
     // SSHFP via generic, :fqdn:n:rdata:ttl:timestamp:lo
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 44) throw new Error('SSHFP fromTinydns, invalid n')
+    if (n != 44) this.throwHelp('SSHFP fromTinydns, invalid n')
 
     return new SSHFP({
       owner: this.fullyQualify(fqdn),

--- a/rr/svcb.js
+++ b/rr/svcb.js
@@ -21,7 +21,7 @@ export default class SVCB extends RR {
   }
 
   setParams(val) {
-    // if (!val) throw new Error(`SVCB: value is required, ${this.citeRFC()}`)
+    // if (!val) throw new Error(`SVCB: params is required`)
 
     this.set('params', val)
   }

--- a/rr/tlsa.js
+++ b/rr/tlsa.js
@@ -10,21 +10,19 @@ export default class TLSA extends RR {
   /****** Resource record specific setters   *******/
   setCertificateUsage(val) {
     if (![0, 1, 2, 3].includes(val))
-      throw new Error(`TLSA: certificate usage invalid, ${this.citeRFC()}`)
+      this.throwHelp(`TLSA: certificate usage invalid`)
 
     this.set('certificate usage', val)
   }
 
   setSelector(val) {
-    if (![0, 1].includes(val))
-      throw new Error(`TLSA: selector invalid, ${this.citeRFC()}`)
+    if (![0, 1].includes(val)) this.throwHelp(`TLSA: selector invalid`)
 
     this.set('selector', val)
   }
 
   setMatchingType(val) {
-    if (![0, 1, 2].includes(val))
-      throw new Error(`TLSA: matching type, ${this.citeRFC()}`)
+    if (![0, 1, 2].includes(val)) this.throwHelp(`TLSA: matching type`)
 
     this.set('matching type', val)
   }
@@ -65,7 +63,7 @@ export default class TLSA extends RR {
     const match = opts.bindline.split(
       /^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+([0-9]+)\s+([0-9]+)\s+([0-9]+)\s+(.*?)\s*$/,
     )
-    if (!match) throw new Error(`unable to parse TLSA: ${opts.bindline}`)
+    if (!match) this.throwHelp(`unable to parse TLSA: ${opts.bindline}`)
     const [owner, ttl, c, type, usage, selector, matchtype, cad] =
       match.slice(1)
     return new TLSA({
@@ -82,7 +80,7 @@ export default class TLSA extends RR {
 
   fromTinydns(opts) {
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 52) throw new Error('TLSA fromTinydns, invalid n')
+    if (n != 52) this.throwHelp('TLSA fromTinydns, invalid n')
 
     const bytes = Buffer.from(TINYDNS.octalToChar(rdata), 'binary')
 

--- a/rr/txt.js
+++ b/rr/txt.js
@@ -54,7 +54,7 @@ export default class TXT extends RR {
     // generic: :fqdn:n:rdata:ttl:timestamp:location
     // eslint-disable-next-line prefer-const
     let [fqdn, n, rdata, ttl, ts, loc] = str.substring(1).split(':')
-    if (n != 16) throw new Error('TXT fromTinydns, invalid n')
+    if (n != 16) this.throwHelp('TXT fromTinydns, invalid n')
 
     rdata = TINYDNS.octalToChar(rdata)
     let s = ''
@@ -73,7 +73,7 @@ export default class TXT extends RR {
     const match = opts.bindline.split(
       /^([^\s]+)\s+([0-9]+)\s+(\w+)\s+(\w+)\s+?\s*(.*?)\s*$/,
     )
-    if (!match) throw new Error(`unable to parse TXT: ${opts.bindline}`)
+    if (!match) this.throwHelp(`unable to parse TXT: ${opts.bindline}`)
     const [owner, ttl, c, type, rdata] = match.slice(1)
 
     return new this.constructor({

--- a/rr/uri.js
+++ b/rr/uri.js
@@ -21,7 +21,7 @@ export default class URI extends RR {
   }
 
   setTarget(val) {
-    if (!val) throw new Error(`URI: target is required, ${this.citeRFC()}`)
+    if (!val) this.throwHelp(`URI: target is required`)
 
     this.set('target', val)
   }
@@ -30,7 +30,7 @@ export default class URI extends RR {
   fromTinydns(opts) {
     // URI via generic, :fqdn:n:rdata:ttl:timestamp:lo
     const [fqdn, n, rdata, ttl, ts, loc] = opts.tinyline.substring(1).split(':')
-    if (n != 256) throw new Error('URI fromTinydns, invalid n')
+    if (n != 256) this.throwHelp('URI fromTinydns, invalid n')
 
     return new URI({
       type: 'URI',

--- a/test/base.js
+++ b/test/base.js
@@ -4,7 +4,7 @@ export function valid(type, validRecords, defaults) {
   describe('valid', function () {
     for (const val of validRecords) {
       // console.log(val)
-      it(`parses record: ${val.owner}`, async function () {
+      it(`parses record: ${val.owner}`, function () {
         if (defaults) val.default = defaults
         const r = new type(val)
         if (defaults) delete val.default
@@ -27,7 +27,7 @@ export function invalid(type, invalidRecords, defaults) {
   describe('invalid', function () {
     for (const inv of invalidRecords) {
       if (defaults) inv.default = defaults
-      it(`throws on record (${inv.owner})`, async function () {
+      it(`throws on record (${inv.owner})`, function () {
         assert.throws(
           () => {
             new type(inv)
@@ -44,7 +44,7 @@ export function invalid(type, invalidRecords, defaults) {
 export function toBind(type, validRecords) {
   describe('toBind', function () {
     for (const val of validRecords) {
-      it(`exports to BIND: ${val.owner}`, async function () {
+      it(`exports to BIND: ${val.owner}`, function () {
         const r = new type(val).toBind()
         if (process.env.DEBUG) console.dir(r)
         assert.strictEqual(r, val.testB)
@@ -57,7 +57,7 @@ export function toTinydns(type, validRecords) {
   describe('toTinydns', function () {
     for (const val of validRecords) {
       if (val.testT === undefined) continue
-      it(`exports to tinydns: ${val.owner}`, async function () {
+      it(`exports to tinydns: ${val.owner}`, function () {
         const r = new type(val).toTinydns()
         if (process.env.DEBUG) console.dir(r)
         assert.strictEqual(r, val.testT)
@@ -69,7 +69,7 @@ export function toTinydns(type, validRecords) {
 export function getDescription(type) {
   describe('getDescription', function () {
     const desc = new type(null).getDescription()
-    it(`gets description: ${desc}`, async function () {
+    it(`gets description: ${desc}`, function () {
       assert.ok(desc)
     })
   })
@@ -79,7 +79,7 @@ export function getRFCs(type, valid) {
   describe('getRFCs', function () {
     const r = new type(null)
     const rfcs = r.getRFCs()
-    it(`can retrieve RFCs: ${rfcs.join(',')}`, async function () {
+    it(`can retrieve RFCs: ${rfcs.join(',')}`, function () {
       assert.ok(rfcs.length)
     })
   })
@@ -89,7 +89,7 @@ function checkFromNS(type, validRecords, nsName, nsLineName) {
   for (const val of validRecords) {
     const testLine = nsLineName === 'bindline' ? val.testB : val.testT
     if (testLine == undefined) continue
-    it(`imports ${nsName} record: ${val.owner}`, async function () {
+    it(`imports ${nsName} record: ${val.owner}`, function () {
       const r = new type({ [nsLineName]: testLine })
       if (process.env.DEBUG) console.dir(r)
       for (const f of r.getFields()) {
@@ -122,7 +122,7 @@ export function fromBind(type, validRecords) {
 export function getRdataFields(type, rdataFields) {
   describe('getRdataFields', function () {
     const r = new type(null)
-    it(`can retrieve rdata fields: (${r.getRdataFields('rdata')})`, async function () {
+    it(`can retrieve rdata fields: (${r.getRdataFields('rdata')})`, function () {
       assert.deepEqual(r.getRdataFields('rdata'), rdataFields)
     })
   })
@@ -131,7 +131,7 @@ export function getRdataFields(type, rdataFields) {
 export function getFields(type, rdataFields) {
   describe('getFields', function () {
     const r = new type(null)
-    it(`can retrieve record fields`, async function () {
+    it(`can retrieve record fields`, function () {
       assert.deepEqual(r.getFields('rdata'), rdataFields)
       assert.deepEqual(r.getFields(), r.getFields('common').concat(rdataFields))
     })
@@ -141,7 +141,7 @@ export function getFields(type, rdataFields) {
 export function getTypeId(type, val) {
   describe('getTypeId', function () {
     const r = new type(null)
-    it(`can retrieve record type ID (${r.getTypeId()})`, async function () {
+    it(`can retrieve record type ID (${r.getTypeId()})`, function () {
       assert.deepEqual(r.getTypeId(), val)
     })
   })

--- a/test/hinfo.js
+++ b/test/hinfo.js
@@ -73,7 +73,7 @@ describe('HINFO record', function () {
       try {
         assert.fail(r[`set${r.ucfirst(f)}`](tooLong))
       } catch (e) {
-        assert.equal(e.message, `HINFO ${f} cannot exceed 255 chars`)
+        assert.ok(/cannot exceed 255 chars/.test(e.message))
       }
     })
   }

--- a/test/rr.js
+++ b/test/rr.js
@@ -102,7 +102,7 @@ describe('RR', function () {
           false,
         )
       } catch (e) {
-        assert.deepEqual(e.message, '$type: $field must be fully qualified')
+        assert.ok(/must be fully qualified/.test(e.message))
       }
     })
   })


### PR DESCRIPTION
## Before

```
> new RR.A({ owner: 'matt.simerson.', type: 'A', ttl: 3600 })
Uncaught Error: A: address is required
    at A.setAddress (file:///Users/matt/git/nictool/dns-resource-record/rr/a.js:12:21)
    at new RR (file:///Users/matt/git/nictool/dns-resource-record/rr.js:25:19)
    at new A (file:///Users/matt/git/nictool/dns-resource-record/rr/a.js:7:5)
```

## After

```
> new RR.A({ owner: 'matt.simerson.', type: 'A', ttl: 3600 })
Uncaught Error: A: address is required

Example A:
{
  'owner' => 'test.example.com.',
  'type' => 'A',
  'ttl' => 3600,
  'class' => 'IN',
  'address' => '192.0.2.127'
}

see RFC 1035

    at A.throwHelp (file:///Users/matt/git/nictool/dns-resource-record/rr.js:133:11)
    at A.setAddress (file:///Users/matt/git/nictool/dns-resource-record/rr/a.js:12:20)
    at new RR (file:///Users/matt/git/nictool/dns-resource-record/rr.js:27:19)
    at new A (file:///Users/matt/git/nictool/dns-resource-record/rr/a.js:7:5)
```